### PR TITLE
closes mxabierto/adela#185

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.1.2
+  - 2.1.5
 env:
   - DB=postgresql
 bundler_args: --without development

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '2.1.2'
+ruby '2.1.5'
 
 gem 'rails', '4.1'
 


### PR DESCRIPTION
Adela needs to upgrade it's ruby version from `2.1.2` to `2.1.5` in order to use [phusion/passenger-docker](https://github.com/phusion/passenger-docker) image.

Fixes #185 