### PR TITLE
closes mxabierto/adela#190

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,2 +1,0 @@
-uri = URI.parse(ENV["REDISTOGO_URL"]) unless Rails.env.test?
-REDIS = Redis.new(:url => ENV['REDISTOGO_URL']) unless Rails.env.test?

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV['REDIS_URL'] }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV['REDIS_URL'] }
+end


### PR DESCRIPTION
In order to connect a Redis Docker container, Adela needs to change it's Redis initializers.

Fixes #190 