### PR TITLE
Enabling Bundler caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.1.5
 env:


### PR DESCRIPTION
Caching the bundle between builds drastically reduces the time a build takes to run.

Closes #163 