### PR TITLE
API para el Plan de Apertura

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'capybara'
   gem 'database_cleaner'
+  gem 'json-schema'
 end
 
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
       jquery-ui-rails (= 4.0.3)
       railties (>= 3.1.0)
     json (1.8.3)
+    json-schema (2.5.0)
+      addressable (~> 2.3)
     kgio (2.9.2)
     launchy (2.4.2)
       addressable (~> 2.3)
@@ -305,6 +307,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   jquery-ui-sass-rails
+  json-schema
   letter_opener
   newrelic_rpm
   pg
@@ -326,3 +329,6 @@ DEPENDENCIES
   unicorn
   validate_url
   will_paginate (~> 3.0)
+
+BUNDLED WITH
+   1.10.5

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,5 +1,5 @@
 class OrganizationsController < ApplicationController
-  before_action :authenticate_user!, except: [:catalog, :show, :search]
+  before_action :authenticate_user!, except: [:catalog, :show, :search, :opening_plan]
 
   layout 'home'
 
@@ -35,6 +35,13 @@ class OrganizationsController < ApplicationController
       end
     else
       render :json => {}
+    end
+  end
+
+  def opening_plan
+    @organization  = Organization.friendly.find(params[:slug])
+    respond_to do |format|
+      format.json { render json: @organization, serializer: OrganizationOpeningPlanSerializer, root: false }
     end
   end
 
@@ -75,5 +82,4 @@ class OrganizationsController < ApplicationController
   def organization_params
     params.require(:organization).permit(:description, :logo_url)
   end
-
 end

--- a/app/serializers/official_serializer.rb
+++ b/app/serializers/official_serializer.rb
@@ -1,0 +1,3 @@
+class OfficialSerializer < ActiveModel::Serializer
+  attributes :kind, :name, :position, :email
+end

--- a/app/serializers/opening_plan_serializer.rb
+++ b/app/serializers/opening_plan_serializer.rb
@@ -1,0 +1,4 @@
+class OpeningPlanSerializer < ActiveModel::Serializer
+  has_many :officials, each_serializer: OfficialSerializer
+  attributes :vision, :name, :description, :publish_date
+end

--- a/app/serializers/organization_opening_plan_serializer.rb
+++ b/app/serializers/organization_opening_plan_serializer.rb
@@ -1,0 +1,11 @@
+class OrganizationOpeningPlanSerializer < ActiveModel::Serializer
+  has_many :opening_plans, each_serializer: OpeningPlanSerializer
+
+  def attributes
+    data ||= {}
+    data[:title] = "Plan de Apertura de #{object.title}"
+    data[:language] = "es"
+    data[:license] = "http://datos.gob.mx/libreusomx/"
+    data.merge super
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Adela::Application.routes.draw do
     end
 
     get "/:slug/catalogo" => "organizations#catalog", :as => "organization_catalog"
+    get "/:slug/plan" => "organizations#opening_plan", :as => "organization_opening_plan"
     root :to => "home#index"
 
 

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe OrganizationsController do
+  describe "GET opening_plan" do
+    let(:organization) { FactoryGirl.create(:organization) }
+
+    it "has 200 status" do
+      { :get => "/#{organization.slug}/plan.json" }
+      expect(response.status).to eq(200)
+    end
+
+    it "routes to organizations#opening_plan" do
+      expect(:get => "/#{organization.slug}/plan.json").to route_to(
+        :controller => "organizations",
+        :action => "opening_plan",
+        :slug   => organization.slug,
+        :locale => "es",
+        :format => "json",
+      )
+    end
+  end
+end

--- a/spec/requests/opening_plan_management_spec.rb
+++ b/spec/requests/opening_plan_management_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+feature "opening plan management" do
+  background do
+    file = File.new("#{Rails.root}/spec/fixtures/files/inventory-with-opening-plan.csv")
+    @inventory = FactoryGirl.create(:published_inventory, csv_file: file)
+  end
+
+  it "returns the organization opening plan" do
+    get "/#{@inventory.organization.slug}/plan.json"
+    expect(response).to match_response_schema("opening_plan")
+  end
+end

--- a/spec/support/api/schemas/opening_plan.json
+++ b/spec/support/api/schemas/opening_plan.json
@@ -1,0 +1,62 @@
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "license": {
+      "type": "string"
+    },
+    "opening_plans": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "vision": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "publish_date": {
+            "type": "string"
+          },
+          "officials": {
+            "type": "array",
+            "items": [
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "title",
+    "language",
+    "license",
+    "opening_plans"
+  ]
+}

--- a/spec/support/api_schema_matcher.rb
+++ b/spec/support/api_schema_matcher.rb
@@ -1,0 +1,7 @@
+RSpec::Matchers.define :match_response_schema do |schema|
+  match do |response|
+    schema_directory = "#{Dir.pwd}/spec/support/api/schemas"
+    schema_path = "#{schema_directory}/#{schema}.json"
+    JSON::Validator.validate!(schema_path, response.body, strict: true)
+  end
+end


### PR DESCRIPTION
Se extiende la API de Adela para consultar el plan de apertura de una organización.

#### Request

```
GET /hacienda/plan.json
```

#### Response

```json
{  
  "title":"Plan de Apertura de Hacienda",
  "language":"es",
  "license":"http://datos.gob.mx/libreusomx/",
  "opening_plans":[  
    {  
      "vision":"Datasets Institutional Vision",
      "name":"Prioritized data sets",
      "description":"Sets description\n",
      "publish_date":"2015-01-07",
      "officials":[  
        {  
          "kind":"admin",
          "name":"Brent Trevor",
          "position":"Admin official",
          "email":"luis.alfredo+admin@ciencias.unam.mx"
        },
        {  
          "kind":"liaison",
          "name":"Elton Spencer",
          "position":"Liaison Official",
          "email":"luis.alfredo+liaison@ciencias.unam.mx"
        }
      ]
    }
  ]
}
```
Esta información también se puede consultar en la [Wiki de la API](https://github.com/mxabierto/adela/wiki/API#plan-de-apertura) de Adela.

Closes #174 