### PR TITLE
Organization gov_type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'factory_girl_rails'
 gem 'validate_url'
 gem 'newrelic_rpm'
 gem 'active_model_warnings'
+gem 'enum_help'
 
 group :development, :test do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       eco-source
       execjs
     eco-source (1.1.0.rc.1)
+    enum_help (0.0.14)
     erubis (2.7.0)
     eventmachine (1.0.3)
     execjs (2.0.2)
@@ -297,6 +298,7 @@ DEPENDENCIES
   database_cleaner
   devise
   eco
+  enum_help
   factory_girl_rails
   figaro
   foreman

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -80,6 +80,6 @@ class OrganizationsController < ApplicationController
   end
 
   def organization_params
-    params.require(:organization).permit(:description, :logo_url)
+    params.require(:organization).permit(:description, :logo_url, :gov_type)
   end
 end

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -1,0 +1,5 @@
+module OrganizationsHelper
+  def options_for_gov_types_select
+    options_for_select(Organization.gov_types_i18n.to_a.map {|k, v| [v, k]}, @organization.gov_type)
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -11,6 +11,8 @@ class Organization < ActiveRecord::Base
   scope :with_catalog, -> { joins(:inventories).where("inventories.published = 't'").uniq }
   scope :title_sorted, -> { order("organizations.title ASC") }
 
+  enum gov_type: [:federal, :state, :municipal, :autonomous]
+
   def current_inventory
     inventories.unpublished.first
   end

--- a/app/views/organizations/profile.html.haml
+++ b/app/views/organizations/profile.html.haml
@@ -21,6 +21,10 @@
               - if @organization.logo_url.present?
                 %br/
                 = image_tag @organization.logo_url, :class => "logo-preview logo-round pull-left"
+          .form-group.text-right
+            = f.label :gov_type, :class => "control-label col-sm-3"
+            .col-sm-9
+              = f.select :gov_type, options_for_gov_types_select, { :include_blank => true }, { :class => "form-control" }
           .form-group
             .submit-row.col-sm-offset-3.col-sm-9.text-right
               = f.button "Guardar", :type => "submit", :class => "btn button"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -125,6 +125,7 @@ es:
       organization:
         description: "Descripción"
         logo_url: "URL Logo"
+        gov_type: "Tipo de Gobierno"
   activemodel:
     errors:
       models:
@@ -162,3 +163,10 @@ es:
   mailers:
     user:
       notificate_user_account_subject: "Nuevo usuario en ADELA"
+  enums:
+    organization:
+      gov_type:
+        federal: "Federal"
+        state: "Estatal"
+        municipal: "Municipal"
+        autonomous: "Organismos Autónomos"

--- a/db/migrate/20150723223356_add_gov_type_to_organization.rb
+++ b/db/migrate/20150723223356_add_gov_type_to_organization.rb
@@ -1,0 +1,6 @@
+class AddGovTypeToOrganization < ActiveRecord::Migration
+  def change
+    add_column :organizations, :gov_type, :integer
+    add_index :organizations, :gov_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150609053948) do
+ActiveRecord::Schema.define(version: 20150723223356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,8 +68,10 @@ ActiveRecord::Schema.define(version: 20150609053948) do
     t.string   "slug"
     t.text     "description"
     t.string   "logo_url"
+    t.integer  "gov_type"
   end
 
+  add_index "organizations", ["gov_type"], name: "index_organizations_on_gov_type", using: :btree
   add_index "organizations", ["slug"], name: "index_organizations_on_slug", unique: true, using: :btree
 
   create_table "roles", force: true do |t|

--- a/spec/features/organization_manages_profile_spec.rb
+++ b/spec/features/organization_manages_profile_spec.rb
@@ -17,6 +17,7 @@ feature Organization, 'manages profile:' do
 
     expect(page).to have_text "Descripción"
     expect(page).to have_text "URL Logo"
+    expect(page).to have_text "Tipo de Gobierno"
   end
 
   scenario "edit description and logo url", :js => true do
@@ -24,6 +25,7 @@ feature Organization, 'manages profile:' do
 
     fill_in "Descripción", :with => "Esta es una descripción de una institución"
     fill_in "URL Logo", :with => "http://www.imageurl.com"
+    select "Federal", :from => "organization[gov_type]"
     click_button "Guardar"
 
     expect(page).to have_text "El perfil se ha actualizado con éxito."


### PR DESCRIPTION
Agrega el campo `gov_type` al modelo `Organization`* como un [ActiveRecord::Enum](http://edgeapi.rubyonrails.org/classes/ActiveRecord/Enum.html). 

Los valores disponibles son:
* Federal
* Estatal
* Municipal
* Organismos Autónomos

![captura de pantalla 2015-07-24 a las 8 12 43](https://cloud.githubusercontent.com/assets/764518/8875646/5485f55a-31e0-11e5-9048-7b1efe8997b2.png)
![captura de pantalla 2015-07-24 a las 8 12 56](https://cloud.githubusercontent.com/assets/764518/8875648/55de5870-31e0-11e5-8143-5f8221869b88.png)

Closes #241 