### PR TITLE
Organizations API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'factory_girl_rails'
 gem 'validate_url'
 gem 'newrelic_rpm'
 gem 'active_model_warnings'
+gem 'enum_help'
 
 group :development, :test do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       eco-source
       execjs
     eco-source (1.1.0.rc.1)
+    enum_help (0.0.14)
     erubis (2.7.0)
     eventmachine (1.0.3)
     execjs (2.0.2)
@@ -297,6 +298,7 @@ DEPENDENCIES
   database_cleaner
   devise
   eco
+  enum_help
   factory_girl_rails
   figaro
   foreman

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -7,6 +7,21 @@ module Api
         @catalogs_urls = Organization.with_catalog.map { |org| organization_catalog_url(:slug => org.slug, :host => request.host, :format => :json)}
         render :json => @catalogs_urls, root: false
       end
+
+      def organizations
+        @organizations = organizations_array.paginate(:page => params[:page])
+        render :json => @organizations, serializer: OrganizationAPISerializer, root: false
+      end
+
+      private
+
+      def organizations_array
+        if Organization.gov_types.has_key?(params[:gov_type])
+          Organization.send(params[:gov_type])
+        else
+          Organization.all
+        end
+      end
     end
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -11,6 +11,10 @@ class OrganizationsController < ApplicationController
     if current_organization.present? && @organization.current_inventory && !@organization.current_catalog
       flash.now[:alert] = "OJO: No has completado el último paso que es publicar tu inventario."
     end
+    respond_to do |format|
+      format.html
+      format.json { render json: @organization, root: false  }
+    end
   end
 
   def publish_catalog

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -80,6 +80,6 @@ class OrganizationsController < ApplicationController
   end
 
   def organization_params
-    params.require(:organization).permit(:description, :logo_url)
+    params.require(:organization).permit(:description, :logo_url, :gov_type)
   end
 end

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -1,0 +1,5 @@
+module OrganizationsHelper
+  def options_for_gov_types_select
+    options_for_select(Organization.gov_types_i18n.to_a.map {|k, v| [v, k]}, @organization.gov_type)
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -11,6 +11,8 @@ class Organization < ActiveRecord::Base
   scope :with_catalog, -> { joins(:inventories).where("inventories.published = 't'").uniq }
   scope :title_sorted, -> { order("organizations.title ASC") }
 
+  enum gov_type: [:federal, :state, :municipal, :autonomous]
+
   def current_inventory
     inventories.unpublished.first
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,6 +10,10 @@ class Organization < ActiveRecord::Base
 
   scope :with_catalog, -> { joins(:inventories).where("inventories.published = 't'").uniq }
   scope :title_sorted, -> { order("organizations.title ASC") }
+  scope :federal, -> { where("gov_type = ?", Organization.gov_types[:federal]) }
+  scope :state, -> { where("gov_type = ?", Organization.gov_types[:state]) }
+  scope :municipal, -> { where("gov_type = ?", Organization.gov_types[:municipal]) }
+  scope :autonomous, -> { where("gov_type = ?", Organization.gov_types[:autonomous]) }
 
   enum gov_type: [:federal, :state, :municipal, :autonomous]
 

--- a/app/serializers/organization_api_serializer.rb
+++ b/app/serializers/organization_api_serializer.rb
@@ -1,0 +1,16 @@
+class OrganizationAPISerializer < ActiveModel::Serializer
+  has_many :results, each_serializer: OrganizationSerializer
+  attributes :results, :pagination
+
+  def results
+    object
+  end
+
+  def pagination
+    {
+      count: object.size,
+      page: object.current_page,
+      per_page: object.per_page,
+    }
+  end
+end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -1,0 +1,3 @@
+class OrganizationSerializer < ActiveModel::Serializer
+  attributes :title, :slug, :description, :logo_url, :gov_type, :created_at, :updated_at
+end

--- a/app/views/organizations/profile.html.haml
+++ b/app/views/organizations/profile.html.haml
@@ -21,6 +21,10 @@
               - if @organization.logo_url.present?
                 %br/
                 = image_tag @organization.logo_url, :class => "logo-preview logo-round pull-left"
+          .form-group.text-right
+            = f.label :gov_type, :class => "control-label col-sm-3"
+            .col-sm-9
+              = f.select :gov_type, options_for_gov_types_select, { :include_blank => true }, { :class => "form-control" }
           .form-group
             .submit-row.col-sm-offset-3.col-sm-9.text-right
               = f.button "Guardar", :type => "submit", :class => "btn button"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -125,6 +125,7 @@ es:
       organization:
         description: "Descripción"
         logo_url: "URL Logo"
+        gov_type: "Tipo de Gobierno"
   activemodel:
     errors:
       models:
@@ -162,3 +163,10 @@ es:
   mailers:
     user:
       notificate_user_account_subject: "Nuevo usuario en ADELA"
+  enums:
+    organization:
+      gov_type:
+        federal: "Federal"
+        state: "Estatal"
+        municipal: "Municipal"
+        autonomous: "Organismos Autónomos"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,10 +30,12 @@ Adela::Application.routes.draw do
     namespace :v1 do
 
       get "/catalogs" => "organizations#catalogs"
+      get "/organizations" => "organizations#organizations"
 
       resources :organizations do
         collection do
           get "catalogs"
+          get "organizations"
         end
       end
     end

--- a/db/migrate/20150723223356_add_gov_type_to_organization.rb
+++ b/db/migrate/20150723223356_add_gov_type_to_organization.rb
@@ -1,0 +1,6 @@
+class AddGovTypeToOrganization < ActiveRecord::Migration
+  def change
+    add_column :organizations, :gov_type, :integer
+    add_index :organizations, :gov_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150609053948) do
+ActiveRecord::Schema.define(version: 20150723223356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,8 +68,10 @@ ActiveRecord::Schema.define(version: 20150609053948) do
     t.string   "slug"
     t.text     "description"
     t.string   "logo_url"
+    t.integer  "gov_type"
   end
 
+  add_index "organizations", ["gov_type"], name: "index_organizations_on_gov_type", using: :btree
   add_index "organizations", ["slug"], name: "index_organizations_on_slug", unique: true, using: :btree
 
   create_table "roles", force: true do |t|

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -1,9 +1,16 @@
 require 'spec_helper'
 
 describe OrganizationsController do
-  describe "GET opening_plan" do
-    let(:organization) { FactoryGirl.create(:organization) }
+  let(:organization) { FactoryGirl.create(:organization) }
 
+  describe "GET show" do
+    it "has 200 status" do
+      { :get => "/instituciones/#{organization.slug}.json" }
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe "GET opening_plan" do
     it "has 200 status" do
       { :get => "/#{organization.slug}/plan.json" }
       expect(response.status).to eq(200)

--- a/spec/features/organization_manages_profile_spec.rb
+++ b/spec/features/organization_manages_profile_spec.rb
@@ -17,6 +17,7 @@ feature Organization, 'manages profile:' do
 
     expect(page).to have_text "Descripción"
     expect(page).to have_text "URL Logo"
+    expect(page).to have_text "Tipo de Gobierno"
   end
 
   scenario "edit description and logo url", :js => true do
@@ -24,6 +25,7 @@ feature Organization, 'manages profile:' do
 
     fill_in "Descripción", :with => "Esta es una descripción de una institución"
     fill_in "URL Logo", :with => "http://www.imageurl.com"
+    select "Federal", :from => "organization[gov_type]"
     click_button "Guardar"
 
     expect(page).to have_text "El perfil se ha actualizado con éxito."

--- a/spec/requests/organization_management_spec.rb
+++ b/spec/requests/organization_management_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+feature "opening plan management" do
+  background do
+    @organization = FactoryGirl.create(:organization)
+  end
+
+  it "returns the organization opening plan" do
+    get "/instituciones/#{@organization.slug}.json"
+    expect(response).to match_response_schema("organization")
+  end
+end

--- a/spec/requests/organizations_api_management_spec.rb
+++ b/spec/requests/organizations_api_management_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+feature "organizations api management" do
+  background do
+    @organization = FactoryGirl.create(:organization)
+  end
+
+  it "matches the organizations json schema" do
+    get "/api/v1/organizations"
+    expect(response).to match_response_schema("organizations")
+  end
+
+  it "gets the organizations with federal gov_type" do
+    @organization = FactoryGirl.create(:organization, title: "sep", gov_type: "federal")
+    get "/api/v1/organizations?gov_type=federal"
+    json = JSON.parse(response.body)
+    expect(json["pagination"]["count"]).to eq(1)
+  end
+
+  it "gets the organizations with state gov_type" do
+    @organization = FactoryGirl.create(:organization, title: "Gobierno de Veracruz", gov_type: "state")
+    get "/api/v1/organizations?gov_type=state"
+    json = JSON.parse(response.body)
+    expect(json["pagination"]["count"]).to eq(1)
+  end
+
+  it "gets the organizations with municipal gov_type" do
+    @organization = FactoryGirl.create(:organization, title: "Huixquilucan", gov_type: "municipal")
+    get "/api/v1/organizations?gov_type=municipal"
+    json = JSON.parse(response.body)
+    expect(json["pagination"]["count"]).to eq(1)
+  end
+
+  it "gets the organizations with autonomous gov_type" do
+    @organization = FactoryGirl.create(:organization, title: "INEGI", gov_type: "autonomous")
+    get "/api/v1/organizations?gov_type=autonomous"
+    json = JSON.parse(response.body)
+    expect(json["pagination"]["count"]).to eq(1)
+  end
+end

--- a/spec/support/api/schemas/organization.json
+++ b/spec/support/api/schemas/organization.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "slug": {
+      "type": "string"
+    },
+    "description": {
+      "type": ["string","null"]
+    },
+    "logo_url": {
+      "type": ["string","null"]
+    },
+    "gov_type": {
+      "type": ["string","null"]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": [
+    "title",
+    "slug",
+    "description",
+    "logo_url",
+    "gov_type",
+    "created_at",
+    "updated_at"
+  ]
+}

--- a/spec/support/api/schemas/organizations.json
+++ b/spec/support/api/schemas/organizations.json
@@ -1,0 +1,63 @@
+{
+  "type": "object",
+  "properties": {
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["string","null"]
+          },
+          "logo_url": {
+            "type": ["string","null"]
+          },
+          "gov_type": {
+            "type": ["string","null"]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "title",
+          "slug",
+          "description",
+          "logo_url",
+          "gov_type",
+          "created_at",
+          "updated_at"
+        ]
+      }
+    },
+    "pagination": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "per_page": {
+          "type": "integer"
+        }
+      }
+    }
+  },
+  "required": [
+    "results",
+    "pagination"
+  ]
+}


### PR DESCRIPTION
Regresa el listado de organizaciones en Adela.
##### Request
```
GET /api/v1/organizations
```
##### Parametros
* `gov_type`, el tipo de dependencia de gobierno. puede ser: `federal`, `state`, `municipal` o `autonomous`

##### Response
```json
{
    "results": [
        {
            "title": "Hacienda",
            "slug": "hacienda",
            "description": "Dinero, Dinero, Dinero",
            "logo_url": "http://seeklogo.com/images/S/SHCP_Secretaria_de_Hacienda_Y_credito_Publico-logo-273AC96C36-seeklogo.com.gif",
            "gov_type": "federal",
            "created_at": "2015-07-21T04:10:36.040Z",
            "updated_at": "2015-07-24T20:03:42.566Z"
        }
    ],
    "pagination": {
        "count": 1,
        "page": 1,
        "per_page": 30
    }
}
```
Esta información se encuentra también en la [Wiki de la API](https://github.com/mxabierto/adela/wiki/API#organizaciones) de Adela.

 Depende del Pull Request pendiente: #243  

Closes: #233 