### PR TITLE
Fixes migrations

### DIFF
--- a/db/migrate/20140501182326_create_catalogs.rb
+++ b/db/migrate/20140501182326_create_catalogs.rb
@@ -1,6 +1,6 @@
-class CreateInventories < ActiveRecord::Migration
+class CreateCatalogs < ActiveRecord::Migration
   def change
-    create_table :inventories do |t|
+    create_table :catalogs do |t|
       t.string :file_location
       t.integer :organization_id
 

--- a/db/migrate/20140505170805_rename_file_location_to_csv_file.rb
+++ b/db/migrate/20140505170805_rename_file_location_to_csv_file.rb
@@ -1,5 +1,5 @@
 class RenameFileLocationToCsvFile < ActiveRecord::Migration
   def change
-    rename_column :inventories, :file_location, :csv_file
+    rename_column :catalogs, :file_location, :csv_file
   end
 end

--- a/db/migrate/20140509160557_add_published_status_to_catalogs.rb
+++ b/db/migrate/20140509160557_add_published_status_to_catalogs.rb
@@ -1,0 +1,5 @@
+class AddPublishedStatusToCatalogs < ActiveRecord::Migration
+  def change
+    add_column :catalogs, :published, :boolean, default: false
+  end
+end

--- a/db/migrate/20140509160557_add_published_status_to_inventories.rb
+++ b/db/migrate/20140509160557_add_published_status_to_inventories.rb
@@ -1,5 +1,0 @@
-class AddPublishedStatusToInventories < ActiveRecord::Migration
-  def change
-    add_column :inventories, :published, :boolean, :default => false
-  end
-end

--- a/db/migrate/20140509201625_add_publish_date_to_catalogs.rb
+++ b/db/migrate/20140509201625_add_publish_date_to_catalogs.rb
@@ -1,0 +1,5 @@
+class AddPublishDateToCatalogs < ActiveRecord::Migration
+  def change
+    add_column :catalogs, :publish_date, :datetime
+  end
+end

--- a/db/migrate/20140509201625_add_publish_date_to_inventories.rb
+++ b/db/migrate/20140509201625_add_publish_date_to_inventories.rb
@@ -1,5 +1,0 @@
-class AddPublishDateToInventories < ActiveRecord::Migration
-  def change
-    add_column :inventories, :publish_date, :datetime
-  end
-end

--- a/db/migrate/20140520170420_add_author_to_catalogs.rb
+++ b/db/migrate/20140520170420_add_author_to_catalogs.rb
@@ -1,0 +1,5 @@
+class AddAuthorToCatalogs < ActiveRecord::Migration
+  def change
+    add_column :catalogs, :author, :string
+  end
+end

--- a/db/migrate/20140520170420_add_author_to_inventories.rb
+++ b/db/migrate/20140520170420_add_author_to_inventories.rb
@@ -1,5 +1,0 @@
-class AddAuthorToInventories < ActiveRecord::Migration
-  def change
-    add_column :inventories, :author, :string
-  end
-end

--- a/db/migrate/20140602222316_add_index_to_catalogs_and_users.rb
+++ b/db/migrate/20140602222316_add_index_to_catalogs_and_users.rb
@@ -1,0 +1,6 @@
+class AddIndexToCatalogsAndUsers < ActiveRecord::Migration
+  def change
+    add_index :catalogs, :organization_id
+    add_index :users, :organization_id
+  end
+end

--- a/db/migrate/20140602222316_add_index_to_inventories_and_users.rb
+++ b/db/migrate/20140602222316_add_index_to_inventories_and_users.rb
@@ -1,6 +1,0 @@
-class AddIndexToInventoriesAndUsers < ActiveRecord::Migration
-  def change
-    add_index :inventories, :organization_id
-    add_index :users, :organization_id
-  end
-end

--- a/db/migrate/20150818230955_rename_inventory_table_to_catalog_table.rb
+++ b/db/migrate/20150818230955_rename_inventory_table_to_catalog_table.rb
@@ -1,5 +1,0 @@
-class RenameInventoryTableToCatalogTable < ActiveRecord::Migration
-  def change
-    rename_table :inventories, :catalogs
-  end
-end


### PR DESCRIPTION
Después de renombrar el modelo de Inventory a Catalog, tenemos el siguiente problema al intentar crear el nuevo modelo de Inventory:

```
bruce-2:adela babasbot$ rake db:migrate
rake aborted!
ActiveRecord::DuplicateMigrationNameError:

Multiple migrations have the name CreateInventories


Tasks: TOP => db:migrate
```

En este PR renombrados los términos también en migraciones, nos preocuparemos más tarde por el renombre de la tabla.