### PR TITLE
Download and Edit buttons #359

### DIFF
--- a/app/controllers/inventories_controller.rb
+++ b/app/controllers/inventories_controller.rb
@@ -17,6 +17,10 @@ class InventoriesController < ApplicationController
     redirect_to inventory_path(@inventory)
   end
 
+  def edit
+    @inventory = Inventory.find(params[:id])
+  end
+
   def update
     @inventory = Inventory.find(params[:id])
     @inventory.update(intentory_params)

--- a/app/views/inventories/edit.html.haml
+++ b/app/views/inventories/edit.html.haml
@@ -5,15 +5,4 @@
     %ul.list
       %li.item
         %span Sube el inventario de datos
-    = form_for @inventory do |f|
-      .form-group
-        %label.block Selecciona el archivo *
-        .file_input
-          = f.file_field :spreadsheet_file
-      .form-group
-        %label.block Selecciona el archivo de la Minuta de Autorizaci&oacute;n del Grupo de Trabajo
-        .file_input
-          = f.file_field :authorization_file
-      .form-group
-        %button.btn.btn-primary{ type: 'submit' } Subir inventario
-      %p * Campos obligatorios
+    = render 'inventories/shared/form'

--- a/app/views/inventories/edit.html.haml
+++ b/app/views/inventories/edit.html.haml
@@ -1,0 +1,19 @@
+.container
+  .card
+    %h3.title Planea
+    %h5.subtitle Inventario de datos
+    %ul.list
+      %li.item
+        %span Sube el inventario de datos
+    = form_for @inventory do |f|
+      .form-group
+        %label.block Selecciona el archivo *
+        .file_input
+          = f.file_field :spreadsheet_file
+      .form-group
+        %label.block Selecciona el archivo de la Minuta de Autorizaci&oacute;n del Grupo de Trabajo
+        .file_input
+          = f.file_field :authorization_file
+      .form-group
+        %button.btn.btn-primary{ type: 'submit' } Subir inventario
+      %p * Campos obligatorios

--- a/app/views/inventories/index.html.haml
+++ b/app/views/inventories/index.html.haml
@@ -3,3 +3,6 @@
     %h3.title Planea
     %h5.subtitle Inventario de datos
     = render partial: 'inventories/shared/list', locals: { inventory: @inventory }
+    - if @inventory.compliant?
+      = link_to 'Descargar Inventario', @inventory.spreadsheet_file.url, class: 'btn btn-primary'
+      = link_to 'Actualizar Inventario', edit_inventory_path(@inventory), class: 'btn btn-primary'

--- a/app/views/inventories/index.html.haml
+++ b/app/views/inventories/index.html.haml
@@ -3,18 +3,3 @@
     %h3.title Planea
     %h5.subtitle Inventario de datos
     = render partial: 'inventories/shared/list', locals: { inventory: @inventory }
-    %p Actualiza el inventario de datos
-    = form_for @new_inventory do |f|
-      .form-group
-        %label.block Selecciona el archivo *
-        .file_input
-          = f.file_field :spreadsheet_file
-        - unless @new_inventory.errors
-          %span.danger El archivo seleccionado no es v&aacute;lido.
-      .form-group
-        %label.block Selecciona el archivo de la Minuta de Autorizaci&oacute;n del Grupo de Trabajo
-        .file_input
-          = f.file_field :authorization_file
-      .form-group
-        %button.btn.btn-primary{ type: 'submit' } Subir inventario
-      %p * Campos obligatorios

--- a/app/views/inventories/new.html.haml
+++ b/app/views/inventories/new.html.haml
@@ -5,15 +5,4 @@
     %ul.list
       %li.item
         %span Sube el inventario de datos
-    = form_for @inventory do |f|
-      .form-group
-        %label.block Selecciona el archivo *
-        .file_input
-          = f.file_field :spreadsheet_file
-      .form-group
-        %label.block Selecciona el archivo de la Minuta de Autorizaci&oacute;n del Grupo de Trabajo
-        .file_input
-          = f.file_field :authorization_file
-      .form-group
-        %button.btn.btn-primary{ type: 'submit' } Subir inventario
-      %p * Campos obligatorios
+    = render 'inventories/shared/form'

--- a/app/views/inventories/shared/_form.html.haml
+++ b/app/views/inventories/shared/_form.html.haml
@@ -1,0 +1,12 @@
+= form_for @inventory do |f|
+  .form-group
+    %label.block Selecciona el archivo *
+    .file_input
+      = f.file_field :spreadsheet_file
+  .form-group
+    %label.block Selecciona el archivo de la Minuta de Autorizaci&oacute;n del Grupo de Trabajo
+    .file_input
+      = f.file_field :authorization_file
+  .form-group
+    %button.btn.btn-primary{ type: 'submit' } Subir inventario
+  %p * Campos obligatorios

--- a/app/views/inventories/show.html.haml
+++ b/app/views/inventories/show.html.haml
@@ -12,20 +12,7 @@
       %ul.list
         %li.item
           %span Actualiza el inventario de datos
-      = form_for @inventory do |f|
-        .form-group
-          %label.block Selecciona el archivo *
-          .file_input
-            = f.file_field :spreadsheet_file
-          - unless @inventory.errors
-            %span.danger El archivo seleccionado no es v&aacute;lido.
-        .form-group
-          %label.block Selecciona el archivo de la Minuta de Autorizaci&oacute;n del Grupo de Trabajo
-          .file_input
-            = f.file_field :authorization_file
-        .form-group
-          %button.btn.btn-primary{ type: 'submit' } Subir inventario
-        %p * Campos obligatorios
+      = render 'inventories/shared/form'
       %p.danger Se encontraron las siguientes observaciones en el archivo de Inventario de Datos:
       %ul.list__warnings
         = render partial: 'inventories/shared/inventory_warnings_list', locals: { inventory: @inventory }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Adela::Application.routes.draw do
       end
     end
 
-    resources :inventories, only: [:index, :new, :create, :show, :update] do
+    resources :inventories, except: :destroy do
       member do
         get 'publish'
       end

--- a/spec/features/user_manages_inventory_spec.rb
+++ b/spec/features/user_manages_inventory_spec.rb
@@ -78,10 +78,22 @@ feature User, 'manages inventory:' do
     expect(current_path).to eq(new_opening_plan_path)
   end
 
+  scenario 'download opening plan' do
+    upload_inventory_with_file("inventario_general_de_datos.xlsx")
+    visit inventories_path
+    expect(page).to have_text('Descargar Inventario')
+  end
+
+  scenario 'edit an opening plan' do
+    upload_inventory_with_file("inventario_general_de_datos.xlsx")
+    visit inventories_path
+    click_on('Actualizar Inventario')
+    expect(current_path).to eq(edit_inventory_path(@inventory))
+  end
+
   def upload_inventory_with_file(file_name)
     spreadsheet_file = File.new("#{Rails.root}/spec/fixtures/files/#{file_name}")
     @inventory = create(:inventory, organization: @user.organization, spreadsheet_file: spreadsheet_file)
     InventoryXLSXParserWorker.new.perform(@inventory.id)
   end
-
 end


### PR DESCRIPTION
### Changes

* Adds a button for updating the inventory.
*  Adds a button with a download link for the inventory spreadsheet_file.
* Keeps DRY the form views.

### Issues

Closes #358 
Closes #359 

### Screenshots

<img width="1548" alt="captura de pantalla 2015-09-10 a las 14 31 18" src="https://cloud.githubusercontent.com/assets/764518/9798748/ac596420-57c8-11e5-98a6-2eac668a45cb.png">