### PR TITLE
Agregar sectores para las organizaciónes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'roo', '~> 2.1.0'
 gem 'roo-xls'
 gem 'deep_cloneable', '~> 2.1.1'
 gem 'jquery-validation-rails'
+gem 'nested_form'
 
 group :development, :test do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,7 @@ GEM
     minitest (5.8.0)
     multi_json (1.11.2)
     multi_xml (0.5.5)
+    nested_form (0.3.2)
     newrelic_rpm (3.12.1.298)
     nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
@@ -345,6 +346,7 @@ DEPENDENCIES
   jquery-validation-rails
   json-schema
   letter_opener
+  nested_form
   newrelic_rpm
   pg
   rack-pjax

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -7,6 +7,7 @@
 //= require jquery.pjax
 //= require jquery.validate
 //= require jquery.validate.additional-methods
+//= require jquery_nested_form
 //= require jquery/validate/messages
 //= require spin
 //= require jquery.spin

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -36,7 +36,12 @@ module Admin
     private
 
     def organization_params
-      params.require(:organization).permit(:title, :description, :logo_url, :gov_type)
+      params.require(:organization).permit(
+        :title,
+        :description,
+        :logo_url,
+        :gov_type,
+        organization_sectors_attributes: [:id, :sector_id, :_destroy])
     end
   end
 end

--- a/app/helpers/sectors_helper.rb
+++ b/app/helpers/sectors_helper.rb
@@ -1,0 +1,5 @@
+module SectorsHelper
+  def options_for_sectors_select
+    Sector.all.map { |sector| [sector.title, sector.id] }
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,6 +12,7 @@ class Organization < ActiveRecord::Base
   has_many :sectors, through: :organization_sectors
 
   accepts_nested_attributes_for :opening_plans
+  accepts_nested_attributes_for :organization_sectors, allow_destroy: true
 
   scope :with_catalog, -> { joins(:catalogs).where("catalogs.published = 't'").uniq }
   scope :title_sorted, -> { order("organizations.title ASC") }

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -7,8 +7,9 @@ class Organization < ActiveRecord::Base
   has_many :users
   has_many :activity_logs
   has_many :opening_plans, dependent: :destroy
-
   has_many :inventories
+  has_many :organization_sectors
+  has_many :sectors, through: :organization_sectors
 
   accepts_nested_attributes_for :opening_plans
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -8,7 +8,7 @@ class Organization < ActiveRecord::Base
   has_many :activity_logs
   has_many :opening_plans, dependent: :destroy
   has_many :inventories
-  has_many :organization_sectors
+  has_many :organization_sectors, dependent: :destroy
   has_many :sectors, through: :organization_sectors
 
   accepts_nested_attributes_for :opening_plans

--- a/app/models/organization_sector.rb
+++ b/app/models/organization_sector.rb
@@ -1,0 +1,4 @@
+class OrganizationSector < ActiveRecord::Base
+  belongs_to :organization
+  belongs_to :sector
+end

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -1,5 +1,5 @@
 class Sector < ActiveRecord::Base
-  has_many :organization_sectors
+  has_many :organization_sectors, dependent: :destroy
   has_many :organizations, through: :organization_sectors
   validates :title, presence: true
 end

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -1,0 +1,3 @@
+class Sector < ActiveRecord::Base
+  validates :title, presence: true
+end

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -1,3 +1,5 @@
 class Sector < ActiveRecord::Base
+  has_many :organization_sectors
+  has_many :organizations, through: :organization_sectors
   validates :title, presence: true
 end

--- a/app/views/admin/organizations/shared/_form.html.haml
+++ b/app/views/admin/organizations/shared/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for([:admin, @organization]) do |f|
+= nested_form_for([:admin, @organization]) do |f|
   .form-group
     = f.label :title
     = f.text_field :title, class: 'form-control'
@@ -11,6 +11,14 @@
   .form-group
     = f.label :gov_type
     = f.select :gov_type, options_for_gov_types_select(@organization), { include_blank: true }, { class: 'form-control' }
+  .form-group
+    = f.label :sectors
+    = f.fields_for :organization_sectors do |sector_form|
+      .form-group
+        = sector_form.select :sector_id, options_for_sectors_select, {}, { class: 'form-control' }
+        = sector_form.link_to_remove 'Eliminar sector'
+  .form-group
+    = f.link_to_add 'Agregar un sector', :organization_sectors
   .form-group
     = link_to 'Cancelar', admin_organizations_path, class: 'btn btn-primary'
     = f.button 'Guardar', type: 'submit', class: 'btn btn-primary'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -152,6 +152,7 @@ es:
         description: "Descripción"
         logo_url: "URL Logo"
         gov_type: "Tipo de Gobierno"
+        sectors: "Sectores"
   activemodel:
     errors:
       models:

--- a/db/migrate/20150922041546_create_sectors.rb
+++ b/db/migrate/20150922041546_create_sectors.rb
@@ -1,0 +1,9 @@
+class CreateSectors < ActiveRecord::Migration
+  def change
+    create_table :sectors do |t|
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150922043158_create_organization_sectors.rb
+++ b/db/migrate/20150922043158_create_organization_sectors.rb
@@ -1,0 +1,10 @@
+class CreateOrganizationSectors < ActiveRecord::Migration
+  def change
+    create_table :organization_sectors do |t|
+      t.references :sector, index: true
+      t.references :organization, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150922041546) do
+ActiveRecord::Schema.define(version: 20150922043158) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,16 @@ ActiveRecord::Schema.define(version: 20150922041546) do
   end
 
   add_index "opening_plans", ["organization_id"], name: "index_opening_plans_on_organization_id", using: :btree
+
+  create_table "organization_sectors", force: true do |t|
+    t.integer  "sector_id"
+    t.integer  "organization_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "organization_sectors", ["organization_id"], name: "index_organization_sectors_on_organization_id", using: :btree
+  add_index "organization_sectors", ["sector_id"], name: "index_organization_sectors_on_sector_id", using: :btree
 
   create_table "organizations", force: true do |t|
     t.string   "title"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150904140416) do
+ActiveRecord::Schema.define(version: 20150922041546) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,6 +112,12 @@ ActiveRecord::Schema.define(version: 20150904140416) do
 
   add_index "roles", ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id", using: :btree
   add_index "roles", ["name"], name: "index_roles_on_name", using: :btree
+
+  create_table "sectors", force: true do |t|
+    t.string   "title"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "users", force: true do |t|
     t.string   "name",                   default: "", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #
@@ -5,4 +6,17 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
-user = FactoryGirl.create(:user)
+
+FactoryGirl.create(:user)
+
+FactoryGirl.create(:sector, title: 'Educación')
+FactoryGirl.create(:sector, title: 'Economía')
+FactoryGirl.create(:sector, title: 'Salud')
+FactoryGirl.create(:sector, title: 'Seguridad y Justicia')
+FactoryGirl.create(:sector, title: 'Infraestructura')
+FactoryGirl.create(:sector, title: 'Finanzas y Contrataciones')
+FactoryGirl.create(:sector, title: 'Geoespacial')
+FactoryGirl.create(:sector, title: 'Energía y Medio Ambiente')
+FactoryGirl.create(:sector, title: 'Cultura y Turismo')
+FactoryGirl.create(:sector, title: 'Desarrollo Sostenible')
+FactoryGirl.create(:sector, title: 'Gobiernos Locales')

--- a/spec/factories/organization_sectors.rb
+++ b/spec/factories/organization_sectors.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :organization_sector do
+    sector
+    organization
+  end
+end

--- a/spec/factories/sectors.rb
+++ b/spec/factories/sectors.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :sector do
+    title { Faker::Lorem.word }
+  end
+end

--- a/spec/features/admin/admin_manages_organizations_spec.rb
+++ b/spec/features/admin/admin_manages_organizations_spec.rb
@@ -66,4 +66,51 @@ feature Admin, 'manages organizations:' do
     expect(page).to have_text(organization.title)
     expect(page).to have_text('ESTATAL')
   end
+
+  scenario "can add a sector", js: true do
+    create(:sector, title: 'Educación')
+    organization = FactoryGirl.create(:organization)
+    new_attributes = FactoryGirl.attributes_for(:organization)
+    visit "/admin/organizations"
+
+    page.find("#organization_#{organization.id}").click
+    click_on 'Editar'
+
+    expect(current_path).to eq(edit_admin_organization_path(organization))
+    click_on 'Agregar un sector'
+    expect(page).to have_text('Eliminar sector')
+
+    click_on 'Guardar'
+
+    organization.reload
+    sees_success_message 'Se ha actualizado la organización exitosamente.'
+    expect(organization.sectors.count).to eq(1)
+  end
+
+  scenario "can delete a sector", js: true do
+    create(:sector, title: 'Educación')
+    organization = FactoryGirl.create(:organization)
+    new_attributes = FactoryGirl.attributes_for(:organization)
+
+    visit "/admin/organizations"
+    page.find("#organization_#{organization.id}").click
+    click_on 'Editar'
+
+    expect(current_path).to eq(edit_admin_organization_path(organization))
+    click_on 'Agregar un sector'
+    click_on 'Guardar'
+    sees_success_message 'Se ha actualizado la organización exitosamente.'
+
+    visit "/admin/organizations"
+    page.find("#organization_#{organization.id}").click
+    click_on 'Editar'
+
+    expect(current_path).to eq(edit_admin_organization_path(organization))
+    click_on 'Eliminar sector'
+    click_on 'Guardar'
+
+    organization.reload
+    sees_success_message 'Se ha actualizado la organización exitosamente.'
+    expect(organization.sectors.count).to eq(0)
+  end
 end

--- a/spec/models/organization_sector_spec.rb
+++ b/spec/models/organization_sector_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe OrganizationSector do
+  context 'with all mandatory fields' do
+    let(:organization_sector) { create(:organization_sector) }
+    it 'should be valid with all mandatory fields' do
+      organization_sector.should be_valid
+    end
+  end
+end

--- a/spec/models/sector_spec.rb
+++ b/spec/models/sector_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Sector do
+  context 'with all mandatory fields' do
+    let(:sector) { create(:sector) }
+    it 'should be valid with all mandatory fields' do
+      sector.should be_valid
+    end
+  end
+
+  context 'without a title' do
+    let(:sector) { build(:sector, title: nil) }
+    it 'should not be valid ' do
+      sector.should_not be_valid
+    end
+  end
+end


### PR DESCRIPTION
Una organización puede tener uno o varios sectores. Los sectores por defecto son:

- EducaciónEconomía
- Salud
- Seguridad y Justicia
- Infraestructura
- Finanzas y Contrataciones
- Geoespacial
- Energía y Medio Ambiente
- Cultura y Turismo
- Desarrollo Sostenible
- Gobiernos Locales

<img width="1432" alt="captura de pantalla 2015-09-22 a las 13 19 37" src="https://cloud.githubusercontent.com/assets/764518/10027477/c8298730-612c-11e5-9058-eb4d16507e9f.png">
<img width="1059" alt="captura de pantalla 2015-09-22 a las 13 19 49" src="https://cloud.githubusercontent.com/assets/764518/10027478/c82df824-612c-11e5-8655-66047eebc948.png">

### How to test

Los sectores de una organización solo se pueden editar desde el panel de administrador. Se necesita una cuenta de admin.

```
# agregamos el rol de admin al usuario semilla (user1@example.com, pass: sectetpassword)
$ rails console
Loading development environment (Rails 4.1.0)
irb(main):001:0> User.last.add_role(:admin)
  User Load (0.7ms)  SELECT  "users".* FROM "users"   ORDER BY "users"."id" ASC LIMIT 1
  Role Load (0.5ms)  SELECT  "roles".* FROM "roles"  WHERE "roles"."name" = 'admin' AND "roles"."resource_type" IS NULL AND "roles"."resource_id" IS NULL  ORDER BY "roles"."id" ASC LIMIT 1
  Role Exists (1.0ms)  SELECT  1 AS one FROM "roles" INNER JOIN "users_roles" ON "roles"."id" = "users_roles"."role_id" WHERE "users_roles"."user_id" = $1 AND "roles"."id" = 1 LIMIT 1  [["user_id", 1]]
=> #<Role id: 1, name: "admin", resource_id: nil, resource_type: nil, created_at: "2015-09-21 05:42:31", updated_at: "2015-09-21 05:42:31">
```
1. Ingresamos al panel de administrador.
2. Entramos a `Ver Organizaciónes`.
3. Editamos la organización.

### Deploy

En una sesion de rails console correr esto:

https://gist.github.com/babasbot/3598327da6bb584755d1

Closes #268 