### PR TITLE
Query organizations by sectors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'roo-xls'
 gem 'deep_cloneable', '~> 2.1.1'
 gem 'jquery-validation-rails'
 gem 'nested_form'
+gem 'has_scope'
 
 group :development, :test do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,9 @@ GEM
       rails (>= 3.2.0)
     haml (4.0.6)
       tilt
+    has_scope (0.6.0)
+      actionpack (>= 3.2, < 5)
+      activesupport (>= 3.2, < 5)
     hike (1.2.3)
     httparty (0.13.5)
       json (~> 1.8)
@@ -337,6 +340,7 @@ DEPENDENCIES
   friendly_id
   gretel
   haml
+  has_scope
   httparty
   i18n
   iso8601

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V1
     class OrganizationsController < ApplicationController
       include Rails.application.routes.url_helpers
+      has_scope :sector
+      has_scope :gov_type
 
       def show
         @organization = Organization.friendly.find(params[:id])
@@ -14,7 +16,7 @@ module Api
       end
 
       def organizations
-        @organizations = organizations_array.paginate(:page => params[:page])
+        @organizations = apply_scopes(Organization).paginate(page: params[:page])
         render :json => @organizations, serializer: OrganizationAPISerializer, root: false
       end
 
@@ -22,16 +24,6 @@ module Api
         @gov_types = Organization.gov_types_i18n.map { |key, value| { id: key, value: value } }
         @gov_types = @gov_types.paginate(:page => params[:page])
         render :json => @gov_types, serializer: GovTypesSerializer, root: false
-      end
-
-      private
-
-      def organizations_array
-        if Organization.gov_types.has_key?(params[:gov_type])
-          Organization.send(params[:gov_type])
-        else
-          Organization.all
-        end
       end
     end
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -16,11 +16,8 @@ class Organization < ActiveRecord::Base
 
   scope :with_catalog, -> { joins(:catalogs).where("catalogs.published = 't'").uniq }
   scope :title_sorted, -> { order("organizations.title ASC") }
-  scope :federal, -> { where("gov_type = ?", Organization.gov_types[:federal]) }
-  scope :state, -> { where("gov_type = ?", Organization.gov_types[:state]) }
-  scope :municipal, -> { where("gov_type = ?", Organization.gov_types[:municipal]) }
-  scope :autonomous, -> { where("gov_type = ?", Organization.gov_types[:autonomous]) }
   scope :sector, -> slug { joins(:sectors).where('sectors.slug = ?', slug) }
+  scope :gov_type, -> gov_type { where('gov_type = ?', Organization.gov_types[gov_type]) }
 
   enum gov_type: [:federal, :state, :municipal, :autonomous]
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -20,6 +20,7 @@ class Organization < ActiveRecord::Base
   scope :state, -> { where("gov_type = ?", Organization.gov_types[:state]) }
   scope :municipal, -> { where("gov_type = ?", Organization.gov_types[:municipal]) }
   scope :autonomous, -> { where("gov_type = ?", Organization.gov_types[:autonomous]) }
+  scope :sector, -> slug { joins(:sectors).where('sectors.slug = ?', slug) }
 
   enum gov_type: [:federal, :state, :municipal, :autonomous]
 

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -1,5 +1,8 @@
 class Sector < ActiveRecord::Base
+  extend FriendlyId
+
   has_many :organization_sectors, dependent: :destroy
   has_many :organizations, through: :organization_sectors
   validates :title, presence: true
+  friendly_id :title, use: [:slugged]
 end

--- a/db/migrate/20150922201558_add_slug_to_sectors.rb
+++ b/db/migrate/20150922201558_add_slug_to_sectors.rb
@@ -1,0 +1,6 @@
+class AddSlugToSectors < ActiveRecord::Migration
+  def change
+    add_column :sectors, :slug, :string
+    add_index :sectors, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150922043158) do
+ActiveRecord::Schema.define(version: 20150922201558) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,7 +127,10 @@ ActiveRecord::Schema.define(version: 20150922043158) do
     t.string   "title"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "slug"
   end
+
+  add_index "sectors", ["slug"], name: "index_sectors_on_slug", unique: true, using: :btree
 
   create_table "users", force: true do |t|
     t.string   "name",                   default: "", null: false

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -19,5 +19,11 @@ FactoryGirl.define do
     trait :autonomous do
       gov_type { 'autonomous' }
     end
+
+    trait :sector do
+      after(:create) do |organization|
+        create(:organization_sector, organization: organization)
+      end
+    end
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -15,4 +15,16 @@ describe Organization do
       @org.should_not be_valid
     end
   end
+
+  context 'sector scope' do
+    before(:each) do
+      @organization = FactoryGirl.create(:organization, :sector)
+    end
+
+    it 'should return the sector organizations' do
+      slug = Sector.last.slug
+      organizations_count = Organization.sector(slug).count
+      expect(organizations_count).to eq(1)
+    end
+  end
 end

--- a/spec/requests/organizations_api_management_spec.rb
+++ b/spec/requests/organizations_api_management_spec.rb
@@ -42,4 +42,12 @@ feature "organizations api management" do
     json = JSON.parse(response.body)
     expect(json["pagination"]["count"]).to eq(1)
   end
+
+  it "gets the organizations with autonomous gov_type" do
+    @organization = FactoryGirl.create(:organization, :sector)
+    @sector = @organization.sectors.first
+    get "api/v1/organizations/?sector=#{@sector.slug}"
+    json = JSON.parse(response.body)
+    expect(json['pagination']['count']).to eq(1)
+  end
 end

--- a/spec/support/api/schemas/sectors.json
+++ b/spec/support/api/schemas/sectors.json
@@ -18,13 +18,17 @@
             },
             "updated_at": {
               "type": "string"
+            },
+            "slug": {
+              "type": "string"
             }
           },
           "required": [
             "id",
             "title",
             "created_at",
-            "updated_at"
+            "updated_at",
+            "slug"
           ]
         }
       ]


### PR DESCRIPTION
# DO NOT MERGE BEFORE #406 
Agrega al endpoint de organizaciónes la busqueda por sector.

Closes  #396

### Request
```
GET /api/v1/organizations?sector=economia
```
### Response
```JSON
{
   "results":[
      {
         "title":"SHCP",
         "slug":"shcp",
         "description":"La Secretaría de Hacienda y Crédito Público tiene como misión proponer, dirigir y controlar la política económica del Gobierno Federal en materia financiera, fiscal, de gasto, de ingresos y deuda pública, con el propósito de consolidar un país con crecimiento económico de calidad, equitativo, incluyente y sostenido, que fortalezca el bienestar de las y los mexicanos.",
         "logo_url":"http://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/SHCP_logo_2012.svg/2000px-SHCP_logo_2012.svg.png",
         "gov_type":"federal",
         "created_at":"2015-09-22T22:57:06.780Z",
         "updated_at":"2015-09-22T22:57:06.780Z"
      }
   ],
   "pagination":{
      "count":1,
      "page":1,
      "per_page":30
   }
}
```