### PR TITLE
Sector keywords #397

### DIFF
--- a/app/models/csv_processor.rb
+++ b/app/models/csv_processor.rb
@@ -4,7 +4,7 @@ class CsvProcessor < Struct.new(:csv_file, :organization)
   def process
     datasets = []
     if csv_file.url.present?
-      CSV.new(csv_file.read.to_utf8, :headers => :first_row).each do |row|
+      CSV.new(csv_file.read.to_utf8, headers: :first_row).each do |row|
         if dataset?(row)
           datasets << new_dataset(row)
         elsif distribution?(row)
@@ -23,57 +23,55 @@ class CsvProcessor < Struct.new(:csv_file, :organization)
 
   def build_dataset_v3(row)
     dataset_attributes = dataset_common_attributes(row)
-    dataset_attributes[:landingPage] = row["ds:landingPage"]
+    dataset_attributes[:landingPage] = row['ds:landingPage']
     DCAT::V3::DataSet.new(dataset_attributes)
   end
 
   def build_dataset_v2(row)
     dataset_attributes = dataset_common_attributes(row)
-    dataset_attributes[:dataDictionary] = row["ds:dataDictionary"]
+    dataset_attributes[:dataDictionary] = row['ds:dataDictionary']
     DCAT::V2::DataSet.new(dataset_attributes)
   end
 
   def dataset_common_attributes(row)
     {
-      :identifier => I18n.transliterate((row["ds:identifier"] || row[0]).force_encoding('utf-8')),
-      :title => row["ds:title"],
-      :description => row["ds:description"],
-      :keyword => row["ds:keyword"],
-      :modified => row["ds:modified"],
-      :contactPoint => row["ds:contactPoint"],
-      :mbox => row["ds:mbox"],
-      :accessLevel => row["ds:accessLevel"],
-      :accessLevelComment => row["ds:accessLevelComment"],
-      :temporal => row["ds:temporal"],
-      :spatial => row["ds:spatial"],
-      :accrualPeriodicity => row["ds:accrualPeriodicity"],
-      :publisher => organization.title,
+      identifier: I18n.transliterate((row['ds:identifier'] || row[0]).force_encoding('utf-8')),
+      title: row['ds:title'],
+      description: row['ds:description'],
+      keyword: row['ds:keyword'],
+      modified: row['ds:modified'],
+      contactPoint: row['ds:contactPoint'],
+      mbox: row['ds:mbox'],
+      accessLevel: row['ds:accessLevel'],
+      accessLevelComment: row['ds:accessLevelComment'],
+      temporal: row['ds:temporal'],
+      spatial: row['ds:spatial'],
+      accrualPeriodicity: row['ds:accrualPeriodicity'],
+      publisher: organization.title
     }
   end
 
   def new_distribution(row)
-    Distribution.new({
-      :title => row["rs:title"],
-      :description => row["rs:description"],
-      :downloadURL => row["rs:downloadURL"],
-      :mediaType => row["rs:mediaType"],
-      :byteSize => row["rs:byteSize"],
-      :temporal => row["rs:temporal"],
-      :spatial => row["rs:spatial"],
-    })
+    Distribution.new(
+      title: row['rs:title'],
+      description: row['rs:description'],
+      downloadURL: row['rs:downloadURL'],
+      mediaType: row['rs:mediaType'],
+      byteSize: row['rs:byteSize'],
+      temporal: row['rs:temporal'],
+      spatial: row['rs:spatial']
+    )
   end
 
   def dataset?(row)
-    (row["ds:identifier"].present? || row[0].present?) && row["ds:title"].present?
+    (row['ds:identifier'].present? || row[0].present?) && row['ds:title'].present?
   end
 
   def distribution?(row)
-    (row["ds:identifier"].present? || row[0].present?) && row["rs:title"].present?
+    (row['ds:identifier'].present? || row[0].present?) && row['rs:title'].present?
   end
 
-  private
-
   def dcat_v3?(row)
-    row.header?("ds:landingPage")
+    row.header?('ds:landingPage')
   end
 end

--- a/app/models/csv_processor.rb
+++ b/app/models/csv_processor.rb
@@ -1,5 +1,6 @@
 class CsvProcessor < Struct.new(:csv_file, :organization)
   String.include CoreExtensions::String::Transcoding
+  String.include CoreExtensions::String::Helpers
 
   def process
     datasets = []
@@ -38,7 +39,7 @@ class CsvProcessor < Struct.new(:csv_file, :organization)
       identifier: I18n.transliterate((row['ds:identifier'] || row[0]).force_encoding('utf-8')),
       title: row['ds:title'],
       description: row['ds:description'],
-      keyword: row['ds:keyword'],
+      keyword: keywords(row),
       modified: row['ds:modified'],
       contactPoint: row['ds:contactPoint'],
       mbox: row['ds:mbox'],
@@ -73,5 +74,11 @@ class CsvProcessor < Struct.new(:csv_file, :organization)
 
   def dcat_v3?(row)
     row.header?('ds:landingPage')
+  end
+
+  def keywords(row)
+    sectors = organization.sectors.map(&:title).join(',')
+    keywords = row['ds:keyword']
+    "#{keywords},#{sectors}".chomp(',').lchomp(',').downcase.strip
   end
 end

--- a/lib/core_extensions/string/helpers.rb
+++ b/lib/core_extensions/string/helpers.rb
@@ -1,0 +1,10 @@
+module CoreExtensions
+  module String
+    module Helpers
+
+      def lchomp(sep = $/)
+        self.start_with?(sep) ? self[sep.size..-1] : self
+      end
+    end
+  end
+end

--- a/spec/models/csv_processor_spec.rb
+++ b/spec/models/csv_processor_spec.rb
@@ -2,14 +2,30 @@ require 'spec_helper'
 
 describe CsvProcessor do
   describe "#process" do
-    subject do
-      CsvProcessor.new(FactoryGirl.create(:catalog).csv_file, FactoryGirl.create(:organization))
+    context "an organization catalog" do
+      subject do
+        CsvProcessor.new(FactoryGirl.create(:catalog).csv_file, FactoryGirl.create(:organization))
+      end
+
+      it "gets the datasets from the file" do
+        subject.process.size.should == 2
+        subject.process[0].distributions.size.should == 3
+        subject.process[1].distributions.size.should == 4
+      end
     end
 
-    it "gets the datasets from the file" do
-      subject.process.size.should == 2
-      subject.process[0].distributions.size.should == 3
-      subject.process[1].distributions.size.should == 4
+    context "an organization with sectors catalog" do
+      subject do
+        organization = create(:organization, :sector)
+        csv_file = create(:catalog).csv_file
+        CsvProcessor.new(csv_file, organization)
+      end
+
+      it "contains the organization sectors in the keywords" do
+        sector_keyword = subject.organization.sectors.first.title
+        includes_sector = subject.process[0].keywords.include?(sector_keyword)
+        expect(includes_sector).to be true
+      end
     end
   end
 end


### PR DESCRIPTION
Agrega los sectores de una organización a los keywords de los datasets del catálogo de una organización.

Closes #397 

### How to test

- [x] Agregar sectores a alguna organización
- [x] Subir un catálogo de datos en esa organización
- [x] Revisar los keywords en el resumen del catálogo
- [ ] Publicar el catálogo y revisar en `/:org-slug:/catalogo.json`
- [ ] PROF IT

<img width="478" alt="captura de pantalla 2015-09-23 a las 16 24 02" src="https://cloud.githubusercontent.com/assets/764518/10059284/b7ec9c0c-620f-11e5-89aa-b07be1c0f477.png">

<img width="486" alt="captura de pantalla 2015-09-23 a las 16 28 02" src="https://cloud.githubusercontent.com/assets/764518/10059356/1f469db2-6210-11e5-8fc6-c7484042ee7e.png">
