### PR TITLE
Updates API pagination metadata

### DIFF
--- a/app/serializers/gov_types_serializer.rb
+++ b/app/serializers/gov_types_serializer.rb
@@ -7,9 +7,9 @@ class GovTypesSerializer < ActiveModel::Serializer
 
   def pagination
     {
-      count: object.size,
       page: object.current_page,
       per_page: object.per_page,
+      total: object.total_entries
     }
   end
 end

--- a/app/serializers/organization_api_serializer.rb
+++ b/app/serializers/organization_api_serializer.rb
@@ -8,9 +8,9 @@ class OrganizationAPISerializer < ActiveModel::Serializer
 
   def pagination
     {
-      count: object.size,
       page: object.current_page,
       per_page: object.per_page,
+      total: object.total_entries
     }
   end
 end

--- a/app/serializers/sectors_serializer.rb
+++ b/app/serializers/sectors_serializer.rb
@@ -7,9 +7,9 @@ class SectorsSerializer < ActiveModel::Serializer
 
   def pagination
     {
-      count: object.size,
       page: object.current_page,
       per_page: object.per_page,
+      total: object.total_entries
     }
   end
 end

--- a/spec/requests/organizations_api_management_spec.rb
+++ b/spec/requests/organizations_api_management_spec.rb
@@ -19,28 +19,28 @@ feature "organizations api management" do
     @organization = FactoryGirl.create(:organization, title: "sep", gov_type: "federal")
     get "/api/v1/organizations?gov_type=federal"
     json = JSON.parse(response.body)
-    expect(json["pagination"]["count"]).to eq(1)
+    expect(json["results"].count).to eq(1)
   end
 
   it "gets the organizations with state gov_type" do
     @organization = FactoryGirl.create(:organization, title: "Gobierno de Veracruz", gov_type: "state")
     get "/api/v1/organizations?gov_type=state"
     json = JSON.parse(response.body)
-    expect(json["pagination"]["count"]).to eq(1)
+    expect(json["results"].count).to eq(1)
   end
 
   it "gets the organizations with municipal gov_type" do
     @organization = FactoryGirl.create(:organization, title: "Huixquilucan", gov_type: "municipal")
     get "/api/v1/organizations?gov_type=municipal"
     json = JSON.parse(response.body)
-    expect(json["pagination"]["count"]).to eq(1)
+    expect(json["results"].count).to eq(1)
   end
 
   it "gets the organizations with autonomous gov_type" do
     @organization = FactoryGirl.create(:organization, title: "INEGI", gov_type: "autonomous")
     get "/api/v1/organizations?gov_type=autonomous"
     json = JSON.parse(response.body)
-    expect(json["pagination"]["count"]).to eq(1)
+    expect(json["results"].count).to eq(1)
   end
 
   it "gets the organizations with autonomous gov_type" do
@@ -48,6 +48,6 @@ feature "organizations api management" do
     @sector = @organization.sectors.first
     get "api/v1/organizations/?sector=#{@sector.slug}"
     json = JSON.parse(response.body)
-    expect(json['pagination']['count']).to eq(1)
+    expect(json['results'].count).to eq(1)
   end
 end

--- a/spec/support/api/schemas/gov_types.json
+++ b/spec/support/api/schemas/gov_types.json
@@ -4,20 +4,20 @@
     "pagination": {
       "type": "object",
       "properties": {
-        "count": {
-          "type": "integer"
-        },
         "page": {
           "type": "integer"
         },
         "per_page": {
           "type": "integer"
+        },
+        "total": {
+          "type": "integer"
         }
       },
       "required": [
-        "count",
         "page",
-        "per_page"
+        "per_page",
+        "total"
       ]
     },
     "results": {

--- a/spec/support/api/schemas/organizations.json
+++ b/spec/support/api/schemas/organizations.json
@@ -44,13 +44,13 @@
     "pagination": {
       "type": "object",
       "properties": {
-        "count": {
-          "type": "integer"
-        },
         "page": {
           "type": "integer"
         },
         "per_page": {
+          "type": "integer"
+        },
+        "total": {
           "type": "integer"
         }
       }

--- a/spec/support/api/schemas/sectors.json
+++ b/spec/support/api/schemas/sectors.json
@@ -36,13 +36,13 @@
     "pagination": {
       "type": "object",
       "properties": {
-        "count": {
-          "type": "integer"
-        },
         "page": {
           "type": "integer"
         },
         "per_page": {
+          "type": "integer"
+        },
+        "total": {
           "type": "integer"
         }
       }


### PR DESCRIPTION
Cambia los metadatos de paginación de acuerto a [mxabierto/api-standards](https://github.com/mxabierto/api-standards).

```JSON
{

    "results": [ ],
    "pagination": 

    {
        "page": 1,
        "per_page": 30,
        "total": 0
    }

}
```

Closes #434 