### PR TITLE
Updates OpeningPlan#create

### DIFF
--- a/app/controllers/opening_plan_controller.rb
+++ b/app/controllers/opening_plan_controller.rb
@@ -16,17 +16,9 @@ class OpeningPlanController < ApplicationController
   end
 
   def create
-    # Keep datasets that were checkboxed
-    org = organization_params
-    plans = org["opening_plans_attributes"]
-    org["opening_plans_attributes"] = plans.keep_if do |k, v|
-      params["included_datasets"].include? v["name"]
-    end
-
     @organization = current_organization
     @organization.opening_plans = []
-    @organization.update(org)
-    @organization.save
+    @organization.update(organization_params)
     redirect_to opening_plan_index_path
   end
 
@@ -72,7 +64,8 @@ class OpeningPlanController < ApplicationController
         :name,
         :description,
         :accrual_periodicity,
-        :publish_date
+        :publish_date,
+        :_destroy
       ]
     )
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -11,7 +11,7 @@ class Organization < ActiveRecord::Base
   has_many :organization_sectors, dependent: :destroy
   has_many :sectors, through: :organization_sectors
 
-  accepts_nested_attributes_for :opening_plans
+  accepts_nested_attributes_for :opening_plans, allow_destroy: true
   accepts_nested_attributes_for :organization_sectors, allow_destroy: true
 
   scope :with_catalog, -> { joins(:catalogs).where("catalogs.published = 't'").uniq }

--- a/app/views/opening_plan/new.html.haml
+++ b/app/views/opening_plan/new.html.haml
@@ -27,7 +27,7 @@
             - @organization.opening_plans.each do |plan|
               = f.fields_for :opening_plans, plan do |builder|
                 %tr
-                  %th= check_box_tag "included_datasets[]", plan.name, 1
+                  %th= builder.check_box :_destroy, {}, '0', '1'
                   %th= builder.text_field :name, readonly: true, required: true
                   %th= builder.text_field :description, required: true
                   %th P&uacute;blico


### PR DESCRIPTION
Adela ahora utiliza el método `destroy` en nested attributes para eliminar los datasets que no se publicaran en el plan de apertura. 

Esto soluciona el bug donde se utilizaba la comparación por titulo del dataset que fallaba en este caso:

`"Eventos Culturales“ != "Eventos Culturales\r\n“`

Closes #448