### PR TITLE
Updates new opening plan view for non public datasets

### DIFF
--- a/app/views/opening_plan/new.html.haml
+++ b/app/views/opening_plan/new.html.haml
@@ -11,7 +11,12 @@
           Publica el inventario de datos
         %p
           Antes de generar el Plan de apertura de la institución debes de subir el Inventario de Datos.
-        = link_to 'Subir', new_inventory_path, class: 'btn btn-primary'
+    - elsif current_inventory.inventory_elements.all?(&:private)
+      .card.padding-top.bg--grey
+        %h5.primary.boldish Tu Inventario de Datos no contiene conjuntos públicos
+        %p
+          El Inventario de Datos debe de contener al menos un conjunto de datos público para generar el Plan de Apertura.
+        = link_to 'Revisar el Inventario de Datos', inventories_es_path, class: 'btn btn-primary'
     - else
       = form_for @organization, url: url_for(controller: 'opening_plan', action: 'create'), html: { class: 'form', id: 'opening-plan-form' }, method: 'post' do |f|
         %table.table.table-striped


### PR DESCRIPTION
Users without public datasets can't generate an opening plan.

<img width="1552" alt="captura de pantalla 2015-09-25 a las 14 21 58" src="https://cloud.githubusercontent.com/assets/764518/10110549/8faec910-6393-11e5-8931-a4bc2e65a62a.png">

Closes #449