### PR TITLE
Fill opening plan #363

### DIFF
--- a/app/controllers/opening_plan_controller.rb
+++ b/app/controllers/opening_plan_controller.rb
@@ -19,6 +19,7 @@ class OpeningPlanController < ApplicationController
     @organization = current_organization
     @organization.opening_plans = []
     @organization.update(organization_params)
+    create_opening_plan_officials
     redirect_to opening_plan_index_path
   end
 
@@ -56,6 +57,25 @@ class OpeningPlanController < ApplicationController
       end
 
     end
+  end
+
+  def create_opening_plan_officials
+    @organization.opening_plans.each do |opening_plan|
+      administrator = create_opening_plan_administrator(opening_plan)
+      liaison = create_opening_plan_liaison(opening_plan)
+    end
+  end
+
+  def create_opening_plan_administrator(opening_plan)
+    user = @organization.administrator.try(:user)
+    return unless user
+    opening_plan.officials.create(email: user.email, name: user.name, kind: 'admin')
+  end
+
+  def create_opening_plan_liaison(opening_plan)
+    user = @organization.liaison.try(:user)
+    return unless user
+    opening_plan.officials.create(email: user.email, name: user.name, kind: 'liaison')
   end
 
   def organization_params

--- a/app/models/official.rb
+++ b/app/models/official.rb
@@ -1,5 +1,4 @@
 class Official < ActiveRecord::Base
-  validates :name, :position, :email, :kind, presence: true
   belongs_to :opening_plan
-  enum kind: [ :liaison, :admin ]
+  enum kind: [:liaison, :admin]
 end

--- a/spec/models/official_spec.rb
+++ b/spec/models/official_spec.rb
@@ -1,31 +1,11 @@
 require 'spec_helper'
 
 describe Official do
-  context "validations" do
+  context 'validations' do
     subject { FactoryGirl.create :official }
 
-    it "should be valid with mandatory fields" do
+    it 'should be valid with mandatory fields' do
       subject.should be_valid
-    end
-
-    it "should not be valid without a name" do
-      subject.name = ""
-      subject.should_not be_valid
-    end
-
-    it "should not be valid without a position" do
-      subject.position = ""
-      subject.should_not be_valid
-    end
-
-    it "should not be valid without an email" do
-      subject.email = ""
-      subject.should_not be_valid
-    end
-
-    it "should not be valid without a kind" do
-      subject.kind = nil
-      subject.should_not be_valid
     end
   end
 end


### PR DESCRIPTION
Al generar el plan de apertura, si una organización tiene designados administrador de datos y enlace de apertura se incluyen en el plan.

Closes #363 

### How to test

1. Agregar un administrador de datos y un enlace de apertura en una organización. Ver #486.
2. Generar un plan de apertura.
3. Descargar el archivo del plan de apertura y verificar los datos.