### PR TITLE
Adds rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ end
 
 group :production do
   gem 'unicorn'
+  gem 'rails_12factor'
 end
 
 # Dev tools and plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,11 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.1.0)
       sprockets-rails (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.4)
+    rails_stdout_logging (0.0.4)
     railties (4.1.0)
       actionpack (= 4.1.0)
       activesupport (= 4.1.0)
@@ -359,6 +364,7 @@ DEPENDENCIES
   rack-cors
   rack-pjax
   rails (= 4.1)
+  rails_12factor
   redis
   rolify
   roo (~> 2.1.0)


### PR DESCRIPTION
This gem enables serving assets in production and setting your logger to standard out, both of which are required to run a Rails 4 application on a twelve-factor provider. 