### PR TITLE
Catalog Datasets

### DIFF
--- a/app/commands/catalog_datasets_generator.rb
+++ b/app/commands/catalog_datasets_generator.rb
@@ -28,7 +28,8 @@ class CatalogDatasetsGenerator
       mbox: organization_administrator.try(:email),
       # TODO: add dct:landing_page field
       # landing_page: Faker::Internet.url,
-      accrual_periodicity: opening_plan.accrual_periodicity
+      accrual_periodicity: opening_plan.accrual_periodicity,
+      publish_date: opening_plan.publish_date
     )
   end
 

--- a/app/controllers/catalogs_controller.rb
+++ b/app/controllers/catalogs_controller.rb
@@ -3,6 +3,8 @@ class CatalogsController < ApplicationController
   before_action :require_opening_plan
 
   def index
+    redirect_to catalog_datasets_path(current_organization.catalog)
+    return
   end
 
   private

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -1,0 +1,4 @@
+class DatasetsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -1,4 +1,5 @@
 class DatasetsController < ApplicationController
   def index
+    @catalog = current_organization.catalog
   end
 end

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -1,0 +1,9 @@
+module DatasetsHelper
+  def published_distributions_percentage(dataset)
+    total = dataset.distributions.count
+    published = dataset.distributions.where(published: true).count
+    (published.to_f / total * 100).to_i
+  rescue
+    0
+  end
+end

--- a/app/views/datasets/index.html.haml
+++ b/app/views/datasets/index.html.haml
@@ -1,0 +1,20 @@
+.container
+  .card
+    %h3 Catálogo de datos
+    %h5 Publica a datos.gob.mx
+    %p
+      Aquí puedes revisar el avance de cada conjunto y editar sus recursos para finalizar el proceso.
+    %table.table.table-striped
+      %tr
+        %th Conjunto de Datos
+        %th Recursos publicados
+        %th Fecha compromiso
+        %th
+      - @catalog.datasets.each do |dataset|
+        %tr
+          %td= dataset.title
+          %td= "#{published_distributions_percentage(dataset)}%"
+          %td= dataset.publish_date.try(:strftime, '%d-%b-%y')
+          %td
+            = link_to 'Editar', edit_dataset_path(dataset)
+            = link_to 'Ver último folio', dataset_path(dataset)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Adela::Application.routes.draw do
     resources :organizations, only: [:show, :update] do
       get 'profile', on: :member
       get 'search', on: :collection
-      resources :catalogs, only: :index do
+      resources :catalogs, only: :index, shallow: true do
         resources :datasets
       end
     end

--- a/db/migrate/20151013144129_add_publish_date_to_datasets.rb
+++ b/db/migrate/20151013144129_add_publish_date_to_datasets.rb
@@ -1,0 +1,5 @@
+class AddPublishDateToDatasets < ActiveRecord::Migration
+  def change
+    add_column :datasets, :publish_date, :datetime
+  end
+end

--- a/db/migrate/20151013154250_add_published_to_distributions.rb
+++ b/db/migrate/20151013154250_add_published_to_distributions.rb
@@ -1,0 +1,5 @@
+class AddPublishedToDistributions < ActiveRecord::Migration
+  def change
+    add_column :distributions, :published, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151013144129) do
+ActiveRecord::Schema.define(version: 20151013154250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 20151013144129) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "modified"
+    t.boolean  "published"
   end
 
   add_index "distributions", ["dataset_id"], name: "index_distributions_on_dataset_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151013035926) do
+ActiveRecord::Schema.define(version: 20151013144129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20151013035926) do
     t.integer  "catalog_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "publish_date"
   end
 
   add_index "datasets", ["catalog_id"], name: "index_datasets_on_catalog_id", using: :btree

--- a/spec/controllers/catalogs_controller_spec.rb
+++ b/spec/controllers/catalogs_controller_spec.rb
@@ -2,6 +2,24 @@ require 'spec_helper'
 
 describe CatalogsController do
   describe 'GET #index' do
+    context 'with an opening plan and inventory' do
+      before(:each) do
+        @organization = create(:organization, :catalog, :opening_plan)
+        @user = create(:user, organization: @organization)
+        sign_in(@user)
+
+        get :index, organization_id: @organization.id, locale: :es
+      end
+
+      it 'has 302 status' do
+        expect(response.status).to eq(302)
+      end
+
+      it 'redirects to catalog_datasets path' do
+        expect(response).to redirect_to(catalog_datasets_path(@organization.catalog))
+      end
+    end
+
     context 'without an inventory' do
       before(:each) do
         @organization = create(:organization)
@@ -22,7 +40,7 @@ describe CatalogsController do
 
     context 'without an opening plan' do
       before(:each) do
-        @organization = create(:organization)
+        @organization = create(:organization, :catalog)
         create(:inventory, organization: @organization)
         @user = create(:user, organization: @organization)
         sign_in(@user)

--- a/spec/factories/datasets.rb
+++ b/spec/factories/datasets.rb
@@ -11,6 +11,7 @@ FactoryGirl.define do
     spatial { Faker::Address.state }
     landing_page { Faker::Internet.url }
     accrual_periodicity 'R/P1Y'
+    publish_date { Faker::Time.forward }
     catalog
 
     trait :distributions do

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -8,6 +8,11 @@ FactoryGirl.define do
     temporal { "#{Faker::Date.backward.iso8601}/#{Faker::Date.forward.iso8601}" }
     modified { Faker::Time.forward }
     spatial { Faker::Address.state }
+    published true
     dataset
+
+    trait :unpublished do
+      published false
+    end
   end
 end

--- a/spec/helpers/datasets_helper_spec.rb
+++ b/spec/helpers/datasets_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe DatasetsHelper do
+  describe '#published_distributions_percentage' do
+
+    before(:each) do
+      @dataset = FactoryGirl.create(:dataset)
+    end
+
+    it 'returns percentage of published distributions' do
+
+      FactoryGirl.create(:distribution, dataset: @dataset)
+      FactoryGirl.create(:distribution, :unpublished, dataset: @dataset)
+      percentage = helper.published_distributions_percentage(@dataset)
+      expect(percentage).to eq(50)
+    end
+
+    it 'returns 0 when dataset has no distributions' do
+      percentage = helper.published_distributions_percentage(@dataset)
+      expect(percentage).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
### Changelog

* Agrega el campo `publish_date` a la tabla Datasets.
* Agrega el campo `published` a la tabla Distributions.
* Al generar el plan de apertura, se toma el valor `publish_date` para el Dataset.
* Agrega la vista de datasets para el catálogo de una organización.

Closes #487 

### How to test

1. Publica un inventario de datos.
1. Genera el plan de apertura.
1. Ingresa a la sección de Catálogo de Datos
1. Proofit

<img width="1552" alt="captura de pantalla 2015-10-13 a las 16 11 55" src="https://cloud.githubusercontent.com/assets/764518/10469075/76f11854-71c8-11e5-9c5d-b3887377baa9.png">