### PR TITLE
Datasets ordenados por fecha de publicación ascendente

### DIFF
--- a/app/models/inventory_dataset_generator.rb
+++ b/app/models/inventory_dataset_generator.rb
@@ -36,6 +36,7 @@ class InventoryDatasetGenerator
       # TODO: add dct:landing_page field
       # dataset.landing_page = Faker::Internet.url
       dataset.accrual_periodicity = 'irregular'
+      dataset.publish_date = DateTime.new(2015, 8, 28)
     end
   end
 

--- a/app/models/opening_plan_dataset_generator.rb
+++ b/app/models/opening_plan_dataset_generator.rb
@@ -26,6 +26,7 @@ class OpeningPlanDatasetGenerator
       # TODO: add dct:landing_page field
       # dataset.landing_page = Faker::Internet.url
       dataset.accrual_periodicity = 'irregular'
+      dataset.publish_date = DateTime.new(2015, 9, 25)
     end
   end
 

--- a/app/views/datasets/index.html.haml
+++ b/app/views/datasets/index.html.haml
@@ -9,8 +9,8 @@
         %th Conjunto de Datos
         %th Recursos publicados
         %th Fecha compromiso
-        %th
-      - @catalog.datasets.each do |dataset|
+        %th Acciones
+      - @catalog.datasets.sort_by(&:publish_date).each do |dataset|
         %tr
           %td= dataset.title
           %td= "#{published_distributions_percentage(dataset)}%"


### PR DESCRIPTION
### Changelog

* Los datasets se muestran en orden de publicación ascendente.
* Se agrega la columna faltante en la lista de catálogos.

### How to test

1. Publica un inventario de datos.
1. Genera el plan de apertura.
1. Ingresa a la sección de Catálogo de Datos
1. Proofit

Closes #466 

<img width="1552" alt="captura de pantalla 2015-10-14 a las 0 42 54" src="https://cloud.githubusercontent.com/assets/764518/10475758/8fd28ab2-720c-11e5-8a6a-9eb493d5294a.png">
