### PR TITLE
dct:landingPage

### DIFF
--- a/app/commands/catalog_datasets_generator.rb
+++ b/app/commands/catalog_datasets_generator.rb
@@ -26,8 +26,7 @@ class CatalogDatasetsGenerator
       description: opening_plan.description,
       contact_point: organization_administrator.try(:name),
       mbox: organization_administrator.try(:email),
-      # TODO: add dct:landing_page field
-      # landing_page: Faker::Internet.url,
+      landing_page: @organization.landing_page,
       accrual_periodicity: opening_plan.accrual_periodicity,
       publish_date: opening_plan.publish_date
     )

--- a/app/models/inventory_dataset_generator.rb
+++ b/app/models/inventory_dataset_generator.rb
@@ -33,8 +33,7 @@ class InventoryDatasetGenerator
       dataset.contact_point = organization_administrator.try(:name)
       dataset.mbox = organization_administrator.try(:email)
       dataset.temporal = Time.current.year
-      # TODO: add dct:landing_page field
-      # dataset.landing_page = Faker::Internet.url
+      dataset.landing_page = @organization.landing_page
       dataset.accrual_periodicity = 'irregular'
       dataset.publish_date = DateTime.new(2015, 8, 28)
     end

--- a/app/models/opening_plan_dataset_generator.rb
+++ b/app/models/opening_plan_dataset_generator.rb
@@ -23,8 +23,7 @@ class OpeningPlanDatasetGenerator
       dataset.contact_point = organization_administrator.try(:name)
       dataset.mbox = organization_administrator.try(:email)
       dataset.temporal = Time.current.year
-      # TODO: add dct:landing_page field
-      # dataset.landing_page = Faker::Internet.url
+      dataset.landing_page = @catalog.organization.landing_page
       dataset.accrual_periodicity = 'irregular'
       dataset.publish_date = DateTime.new(2015, 9, 25)
     end


### PR DESCRIPTION
### Changelog

*  El campo `dct:landingPage` del Dataset contiene la URL de la dependencia por defecto.

### How to test

1. Ingresa la URL de tu organización.
1. Publica un inventario de datos.
1. Genera el plan de apertura.
1. Ingresa a la sección de Catálogo de Datos
1. Proofit

```
bruce-2:adela babasbot$ rails console
Loading development environment (Rails 4.1.0)
irb(main):001:0> Organization.last.catalog.datasets.map(&:landing_page)
  Organization Load (0.5ms)  SELECT  "organizations".* FROM "organizations"   ORDER BY "organizations"."id" DESC LIMIT 1
  Catalog Load (0.3ms)  SELECT  "catalogs".* FROM "catalogs"  WHERE "catalogs"."organization_id" = $1 LIMIT 1  [["organization_id", 1]]
  Dataset Load (0.4ms)  SELECT "datasets".* FROM "datasets"  WHERE "datasets"."catalog_id" = $1  [["catalog_id", 1]]
=> ["http://www.mxabierto.org", "http://www.mxabierto.org", "http://www.mxabierto.org"]
```

Closes #472 