### PR TITLE
Publica catalogo en DGM

### DIFF
--- a/app/controllers/catalogs_controller.rb
+++ b/app/controllers/catalogs_controller.rb
@@ -22,6 +22,7 @@ class CatalogsController < ApplicationController
     @catalog.publish_date = Time.current
     @catalog.save
     publish_distributions
+    harvest_catalog
     notify_administrator
     redirect_to catalog_path(@catalog)
     return
@@ -43,6 +44,11 @@ class CatalogsController < ApplicationController
       distribution = Distribution.find(id)
       distribution.update_column(:state, 'published')
     end
+  end
+
+  def harvest_catalog
+    slug = @catalog.organization.slug
+    ShogunHarvestWorker.perform_async("http://adela.datos.gob.mx/#{slug}/catalogo.json")
   end
 
   def require_opening_plan

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -11,7 +11,7 @@ class OrganizationsController < ApplicationController
   def catalog
     @organization = Organization.friendly.find(params[:slug])
     @catalog = @organization.catalog
-    if @catalog.present? && @catalog.published?
+    if @catalog.present? && @catalog.distributions.map(&:published?).any?
       respond_to do |format|
         format.json { render json: @catalog, root: false }
       end

--- a/app/models/shogun_service.rb
+++ b/app/models/shogun_service.rb
@@ -1,0 +1,9 @@
+class ShogunService
+  include HTTParty
+  base_uri SHOGUN_BASE_URI
+
+  def self.harvest(catalog_url)
+    options = { query: { url: catalog_url } }
+    post('/v1/harvest', options)
+  end
+end

--- a/app/serializers/catalog_serializer.rb
+++ b/app/serializers/catalog_serializer.rb
@@ -12,4 +12,10 @@ class CatalogSerializer < ActiveModel::Serializer
     data[:license] = 'http://datos.gob.mx/libreusomx/'
     data.merge super
   end
+
+  def datasets
+    object.datasets.select do |dataset|
+      dataset.distributions.map(&:published?).any?
+    end
+  end
 end

--- a/app/serializers/dataset_serializer.rb
+++ b/app/serializers/dataset_serializer.rb
@@ -15,4 +15,8 @@ class DatasetSerializer < ActiveModel::Serializer
     data[:landing_page] = object.landing_page
     data
   end
+
+  def distributions
+    object.distributions.select(&:published?)
+  end
 end

--- a/app/serializers/dataset_serializer.rb
+++ b/app/serializers/dataset_serializer.rb
@@ -2,7 +2,7 @@ include ActiveModel::Serialization
 
 class DatasetSerializer < ActiveModel::Serializer
   has_many :distributions, root: :distribution
-  attributes :identifier, :title, :description, :modified, :contact_point, :spatial
+  attributes :identifier, :title, :description, :modified, :contactPoint, :spatial
 
   def attributes
     data = super
@@ -12,8 +12,12 @@ class DatasetSerializer < ActiveModel::Serializer
       mbox: object.mbox
     }
     data[:keyword] = object.keywords.split(',')
-    data[:landing_page] = object.landing_page
+    data[:landingPage] = object.landing_page
     data
+  end
+
+  def contactPoint
+    object.contact_point
   end
 
   def distributions

--- a/app/serializers/distribution_serializer.rb
+++ b/app/serializers/distribution_serializer.rb
@@ -1,8 +1,20 @@
 class DistributionSerializer < ActiveModel::Serializer
-  attributes :title, :description, :download_url, :media_type, :byte_size,
+  attributes :title, :description, :downloadURL, :mediaType, :byteSize,
              :temporal, :spatial, :license
 
   def license
     'http://datos.gob.mx/libreusomx/'
+  end
+
+  def downloadURL
+    object.download_url
+  end
+
+  def mediaType
+    object.media_type
+  end
+
+  def byteSize
+    object.byte_size
   end
 end

--- a/app/workers/shogun_harvest_worker.rb
+++ b/app/workers/shogun_harvest_worker.rb
@@ -1,0 +1,7 @@
+class ShogunHarvestWorker
+  include Sidekiq::Worker
+
+  def perform(catalog_url)
+    ShogunService.harvest(catalog_url)
+  end
+end

--- a/config/initializers/shogun.rb
+++ b/config/initializers/shogun.rb
@@ -1,0 +1,1 @@
+SHOGUN_BASE_URI = ENV['SHOGUN_BASE_URI'] || 'shogun-staging.herokuapp.com'

--- a/spec/controllers/catalogs_controller_spec.rb
+++ b/spec/controllers/catalogs_controller_spec.rb
@@ -90,5 +90,10 @@ describe CatalogsController do
       deliveries_count = ActionMailer::Base.deliveries.count
       expect(deliveries_count).to eq(1)
     end
+
+    it 'enqueues the harvest job' do
+      catalog_url = "http://adela.datos.gob.mx/#{@organization.slug}/catalogo.json"
+      expect(ShogunHarvestWorker).to have_enqueued_job(catalog_url)
+    end
   end
 end

--- a/spec/requests/data_catalog_management_spec.rb
+++ b/spec/requests/data_catalog_management_spec.rb
@@ -6,7 +6,11 @@ feature 'data catalog management' do
   end
 
   scenario 'can consume published catalog data' do
-    create(:catalog, :datasets, organization: @organization)
+    catalog = create(:catalog, organization: @organization)
+    dataset = create(:dataset, catalog: catalog)
+    distribution = create(:distribution, dataset: dataset)
+    distribution.update_column(:state, 'published')
+
     get "/#{@organization.slug}/catalogo.json"
     json_response = JSON.parse(response.body)
     json_response['title'].should eql("Catálogo de datos abiertos de #{@organization.title}")
@@ -15,6 +19,7 @@ feature 'data catalog management' do
 
   scenario 'can\'t consume unpublished catalog data' do
     create(:catalog, :unpublished, organization: @organization)
+
     get "/#{@organization.slug}/catalogo.json"
     json_response = JSON.parse(response.body)
     expect(json_response).to eql({})
@@ -29,11 +34,14 @@ feature 'data catalog management' do
   end
 
   scenario 'catalog will have correct DCAT key names' do
-    create(:catalog, :datasets, organization: @organization)
+    catalog = create(:catalog, organization: @organization)
+    dataset = create(:dataset, catalog: catalog)
+    distribution = create(:distribution, dataset: dataset)
+    distribution.update_column(:state, 'published')
 
     dcat_keys = %w(title description homepage issued modified language license dataset)
-    dcat_dataset_keys = %w(identifier title description keyword modified contact_point spatial landing_page language publisher distribution)
-    dcat_distribution_keys = %w(title description license download_url media_type byte_size temporal spatial)
+    dcat_dataset_keys = %w(identifier title description keyword modified contactPoint spatial landingPage language publisher distribution)
+    dcat_distribution_keys = %w(title description license downloadURL mediaType byteSize temporal spatial)
 
     get "/#{@organization.slug}/catalogo.json"
     json_response = JSON.parse(response.body)

--- a/spec/workers/shogun_harvest_worker_spec.rb
+++ b/spec/workers/shogun_harvest_worker_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe ShogunHarvestWorker do
+  let(:catalog_url) { Faker::Internet.url }
+
+  before(:each) do
+    ShogunHarvestWorker.perform_async(catalog_url)
+  end
+
+  it 'enqueues the harvest job' do
+    expect(ShogunHarvestWorker).to have_enqueued_job(catalog_url)
+  end
+end


### PR DESCRIPTION
### Changelog

* Después de publicar las distribuciones de un dataset, se sincroniza el catalogo con shogun.
* `GET /:slug:/catalogo.json` solo muestra los datasets con distribuciones publicadas.
* `GET /:slug:/catalogo.json` solo muestra distribuciones publicadas.

### How to test

1. Publica un catalogo de datos
1. Consulta la API del catalogo en `GET /:slug:/catalogo.json`
1. PROOFIT

Closes #456 

<img width="1551" alt="captura de pantalla 2015-10-20 a las 1 11 19" src="https://cloud.githubusercontent.com/assets/764518/10599419/8b874136-76c7-11e5-8d71-ee9358bd12e6.png">