### PR TITLE
Set call-to-action to "Completar" only when dist is not compliant

### DIFF
--- a/app/helpers/distributions_helper.rb
+++ b/app/helpers/distributions_helper.rb
@@ -1,6 +1,6 @@
 module DistributionsHelper
   def edit_link_to_text(distribution)
-    distribution.published? ? 'Actualizar' : 'Completar'
+    distribution.broke? ? 'Completar' : 'Actualizar'
   end
 
   def state_description(distribution)


### PR DESCRIPTION
Fixes #576 

<img width="1026" alt="screen shot 2015-10-20 at 12 44 09 am" src="https://cloud.githubusercontent.com/assets/705860/10599012/0fd15d40-76c4-11e5-9712-c930b9c14f46.png">
<img width="1067" alt="screen shot 2015-10-20 at 12 44 24 am" src="https://cloud.githubusercontent.com/assets/705860/10599013/0fd3be0a-76c4-11e5-9348-bbe7d4ab7b85.png">
<img width="1081" alt="screen shot 2015-10-20 at 12 44 40 am" src="https://cloud.githubusercontent.com/assets/705860/10599014/0fd6aac0-76c4-11e5-9753-b3c0e66a8709.png">


-----

Como hay 3 estados: `broke, validated, published ` decidí mejor voltear la condición a mostrar "completar" sólo cuando esté rota la distribución (es decir, non-compliant), ya que en los otros 2 estados debe decir Actualizar