### PR TITLE
Set checkbox true for validated distributions on datasets#index

### DIFF
--- a/app/views/datasets/index.html.haml
+++ b/app/views/datasets/index.html.haml
@@ -37,7 +37,7 @@
               %tr
                 %td.nested
                   - if distribution.validated?
-                    = check_box_tag('catalog[distribution_ids][]', distribution.id, false, class: 'cell-checkbox little-margin-right')
+                    = check_box_tag('catalog[distribution_ids][]', distribution.id, true, class: 'cell-checkbox little-margin-right')
                   = distribution.title
                 %td= state_description(distribution)
                 %th


### PR DESCRIPTION
Fixes #577 

Como el checkbox sólo se muestra en distribuciones válidas, sólo basta con dejarlo true por default. En general sí sólo mostraremos checkboxes en cosas publicables, entonces el default debe ser true.

<img width="1130" alt="screen shot 2015-10-20 at 12 53 12 am" src="https://cloud.githubusercontent.com/assets/705860/10599183/2f51d180-76c5-11e5-934f-1f6493889948.png">
