### PR TITLE
Updates the inventory dataset identifier

### DIFF
--- a/app/models/inventory_dataset_generator.rb
+++ b/app/models/inventory_dataset_generator.rb
@@ -26,7 +26,7 @@ class InventoryDatasetGenerator
 
   def build_dataset
     @catalog.datasets.build do |dataset|
-      dataset.identifier = 'inventario-institucional-de-datos'
+      dataset.identifier = "#{@organization.slug}-inventario-institucional-de-datos"
       dataset.title = 'Inventario Institucional de Datos'
       dataset.description = "Inventario Institucional de Datos de #{@organization.title}"
       dataset.keyword = 'inventario'

--- a/spec/models/inventory_dataset_generator_spec.rb
+++ b/spec/models/inventory_dataset_generator_spec.rb
@@ -25,5 +25,14 @@ describe InventoryDatasetGenerator do
       dataset = catalog.datasets.last
       expect(dataset.distributions.count).to eql(1)
     end
+
+    it 'should contain an identifier with the organization slug' do
+      catalog = @inventory.organization.catalog
+      organization_slug = catalog.organization.slug
+      dataset_identifier = catalog.datasets.last.identifier
+      expected_identifier = "#{organization_slug}-inventario-institucional-de-datos"
+
+      expect(dataset_identifier).to eql(expected_identifier)
+    end
   end
 end


### PR DESCRIPTION
### Changelog

* Agrega el slug de la organización en el campo `identifier` del dataset.

### How to test

1. Subir un inventario de datos
1. Publicar el plan de apertura
1. Editar el conjunto de datos del inventario

### Deploy

En una sesión de rails console, correr el siguiente script:

https://gist.github.com/babasbot/1a53976fac8801cb82d5

Closes #639

![captura de pantalla 2015-10-25 a las 5 25 07 p m](https://cloud.githubusercontent.com/assets/764518/10718655/945031ea-7b3d-11e5-9676-6e5a8491f7fb.png) 