### PR TITLE
Updates the opening plan dataset identifier

### DIFF
--- a/app/models/opening_plan_dataset_generator.rb
+++ b/app/models/opening_plan_dataset_generator.rb
@@ -16,7 +16,7 @@ class OpeningPlanDatasetGenerator
 
   def build_dataset
     @catalog.datasets.build do |dataset|
-      dataset.identifier = 'plan-de-apertura-institucional'
+      dataset.identifier = "#{@catalog.organization.slug}-plan-de-apertura-institucional"
       dataset.title = 'Plan de Apertura Institucional'
       dataset.description = "Plan de Apertura Institucional de #{@catalog.organization.title}"
       dataset.keyword = 'plan-de-apertura'

--- a/spec/models/opening_plan_dataset_generator.rb
+++ b/spec/models/opening_plan_dataset_generator.rb
@@ -18,5 +18,13 @@ describe OpeningPlanDatasetGenerator do
       dataset = @catalog.datasets.last
       expect(dataset.distributions.count).to eql(1)
     end
+
+    it 'should contain a dataset with an identifier containing the organization slug' do
+      organization_slug = @catalog.organization.slug
+      dataset_identifier = @catalog.datasets.last.identifier
+      expected_identifier = "#{organization_slug}-plan-de-apertura-institucional"
+
+      expect(dataset_identifier).to eql(expected_identifier)
+    end
   end
 end


### PR DESCRIPTION
### Changelog

* Agrega el slug de la organización en el campo `identifier` del dataset del plan de apertura.

### How to test

1. Subir un inventario de datos
1. Publicar el plan de apertura
1. Editar el conjunto de datos del plan de apertura

### Deploy

Para montar en producción, correr el siguiente script:

https://gist.github.com/babasbot/ca5aed1c2973f06f7176

Closes #640 

![captura de pantalla 2015-10-25 a las 6 01 36 p m](https://cloud.githubusercontent.com/assets/764518/10718898/a20a2714-7b42-11e5-8783-6d196c5f4167.png)
