### PR TITLE
Fix distribution metadata

### DIFF
--- a/app/models/inventory_dataset_generator.rb
+++ b/app/models/inventory_dataset_generator.rb
@@ -97,6 +97,7 @@ class InventoryDatasetGenerator
       distribution.media_type = 'application/vnd.ms-excel'
       distribution.byte_size = @inventory.spreadsheet_file.file.size
       distribution.temporal = build_temporal(dataset.modified)
+      distribution.modified = dataset.modified
     end
   end
 end

--- a/app/models/inventory_dataset_generator.rb
+++ b/app/models/inventory_dataset_generator.rb
@@ -34,6 +34,7 @@ class InventoryDatasetGenerator
     distribution.download_url = @inventory.spreadsheet_file.url
     distribution.byte_size = @inventory.spreadsheet_file.file.size
     distribution.modified = Time.current.iso8601
+    distribution.temporal = build_temporal(distribution.modified)
     distribution.save
   end
 
@@ -83,6 +84,11 @@ class InventoryDatasetGenerator
     end
   end
 
+  def build_temporal(date)
+    "P3H33M/" + date.strftime("%FT%T%:z")
+  end
+
+
   def build_distribution(dataset)
     dataset.distributions.build do |distribution|
       distribution.title = 'Inventario Institucional de Datos'
@@ -90,7 +96,7 @@ class InventoryDatasetGenerator
       distribution.download_url = @inventory.spreadsheet_file.url
       distribution.media_type = 'application/vnd.ms-excel'
       distribution.byte_size = @inventory.spreadsheet_file.file.size
-      distribution.temporal = Time.current.year
+      distribution.temporal = build_temporal(dataset.modified)
     end
   end
 end

--- a/spec/models/inventory_dataset_generator_spec.rb
+++ b/spec/models/inventory_dataset_generator_spec.rb
@@ -30,6 +30,13 @@ describe InventoryDatasetGenerator do
 
         expect(dataset_identifier).to eql(expected_identifier)
       end
+
+      it 'should set a temporal range for the existing distributions' do
+        dataset       = organization.catalog.datasets.last
+        distribution  = dataset.distributions.last
+        timestring    = "P3H33M/#{dataset.modified.strftime("%FT%T%:z")}"
+        expect(distribution.temporal).to eq(timestring)
+      end
     end
 
     context 'an existing inventory' do
@@ -71,6 +78,12 @@ describe InventoryDatasetGenerator do
         old_distribution_download_url = @old_dataset.distributions.first.download_url
         new_distribution_download_url = @new_dataset.distributions.first.download_url
         expect(new_distribution_download_url).not_to eql(old_distribution_download_url)
+      end
+
+      it 'should update temporal range for the existing distribution' do
+        resource    = @new_dataset.distributions.first
+        timestring  = "P3H33M/#{resource.modified.strftime("%FT%T%:z")}"
+        expect(resource.temporal).to eq(timestring)
       end
     end
   end

--- a/spec/models/inventory_dataset_generator_spec.rb
+++ b/spec/models/inventory_dataset_generator_spec.rb
@@ -31,7 +31,13 @@ describe InventoryDatasetGenerator do
         expect(dataset_identifier).to eql(expected_identifier)
       end
 
-      it 'should set a temporal range for the existing distributions' do
+      it 'should set the modified field for the distribution' do
+        dataset       = organization.catalog.datasets.last
+        distribution  = dataset.distributions.last
+        expect(distribution.modified).to eq(dataset.modified)
+      end
+
+      it 'should set a temporal range for the distributions' do
         dataset       = organization.catalog.datasets.last
         distribution  = dataset.distributions.last
         timestring    = "P3H33M/#{dataset.modified.strftime("%FT%T%:z")}"


### PR DESCRIPTION
Fixes #644 

Notas:
- Decidí fijar el temporal del inventario (distribución) como un periodo X partiendo del campo modified. Lo validé con Enrique.
- Cuando se crea una distribución los campos modified y temporal toman como base el dataset.modified
- Cuando se actualiza una distribución los campos modified y temporal toman como base el distribution.modified

How to test:
```bash
➜  adela git:(fix-dataset-metadata) ✗ bundle exec rspec spec/model/inventory_dataset_generator_spec.rb
```