### PR TITLE
Updates the inventory dataset title

### DIFF
--- a/app/models/inventory_dataset_generator.rb
+++ b/app/models/inventory_dataset_generator.rb
@@ -85,7 +85,7 @@ class InventoryDatasetGenerator
 
   def build_distribution(dataset)
     dataset.distributions.build do |distribution|
-      distribution.title = 'Inventario Institucional de Datos'
+      distribution.title = "Inventario Institucional de Datos de #{@organization.title}"
       distribution.description = "Inventario Institucional de Datos de #{@organization.title}"
       distribution.download_url = @inventory.spreadsheet_file.url
       distribution.media_type = 'application/vnd.ms-excel'

--- a/app/models/inventory_dataset_generator.rb
+++ b/app/models/inventory_dataset_generator.rb
@@ -59,7 +59,7 @@ class InventoryDatasetGenerator
   def build_dataset
     @catalog.datasets.build do |dataset|
       dataset.identifier = "#{@organization.slug}-inventario-institucional-de-datos"
-      dataset.title = 'Inventario Institucional de Datos'
+      dataset.title = "Inventario Institucional de Datos de #{@organization.title}"
       dataset.description = "Inventario Institucional de Datos de #{@organization.title}"
       dataset.keyword = 'inventario'
       dataset.modified = Time.current.iso8601

--- a/spec/models/inventory_dataset_generator_spec.rb
+++ b/spec/models/inventory_dataset_generator_spec.rb
@@ -23,6 +23,13 @@ describe InventoryDatasetGenerator do
         expect(dataset.distributions.count).to eql(1)
       end
 
+      it 'should contain a dataset with the organization name in the title' do
+        dataset_title = organization.catalog.datasets.last.title
+        expected_title = "Inventario Institucional de Datos de #{organization.title}"
+
+        expect(dataset_title).to eql(expected_title)
+      end
+
       it 'should contain an identifier with the organization slug' do
         organization_slug = organization.slug
         dataset_identifier = organization.catalog.datasets.last.identifier

--- a/spec/models/inventory_dataset_generator_spec.rb
+++ b/spec/models/inventory_dataset_generator_spec.rb
@@ -30,6 +30,13 @@ describe InventoryDatasetGenerator do
         expect(dataset_title).to eql(expected_title)
       end
 
+      it 'should contain a distribution with the organization name in the title' do
+        distribution_title = organization.catalog.datasets.last.distributions.last.title
+        expected_title = "Inventario Institucional de Datos de #{organization.title}"
+
+        expect(distribution_title).to eql(expected_title)
+      end
+
       it 'should contain an identifier with the organization slug' do
         organization_slug = organization.slug
         dataset_identifier = organization.catalog.datasets.last.identifier


### PR DESCRIPTION
### Changelog

* Agrega el nombre de la organización en el campo `title` del dataset.

### How to test

1. Subir un inventario de datos
1. Publicar el plan de apertura
1. Editar el conjunto de datos del inventario

### Deploy

En una sesión de rails console, correr el siguiente script:

https://gist.github.com/babasbot/7c45cac63a0a4c4bdd57#file-update_title-rb

Closes #671 

![captura de pantalla 2015-10-26 a las 1 27 46 p m](https://cloud.githubusercontent.com/assets/764518/10740023/6f7f09ba-7be5-11e5-9f09-db128b03ba5b.png)
![captura de pantalla 2015-10-26 a las 1 27 51 p m](https://cloud.githubusercontent.com/assets/764518/10740031/7599bcbe-7be5-11e5-99f4-f89481b24739.png)
