### PR TITLE
Dataset Plan de Apertura

### DIFF
--- a/app/models/opening_plan_dataset_generator.rb
+++ b/app/models/opening_plan_dataset_generator.rb
@@ -39,7 +39,7 @@ class OpeningPlanDatasetGenerator
 
   def build_distribution(dataset)
     dataset.distributions.build do |distribution|
-      distribution.title = 'Plan de Apertura Institucional'
+      distribution.title = "Plan de Apertura Institucional de #{@catalog.organization.title}"
       distribution.description = "Plan de Apertura Institucional de #{@catalog.organization.title}"
       distribution.download_url = "http://adela.datos.gob.mx/plan-de-apertura/#{@catalog.organization.slug}/export.csv"
       distribution.media_type = 'text/csv'

--- a/app/models/opening_plan_dataset_generator.rb
+++ b/app/models/opening_plan_dataset_generator.rb
@@ -17,7 +17,7 @@ class OpeningPlanDatasetGenerator
   def build_dataset
     @catalog.datasets.build do |dataset|
       dataset.identifier = "#{@catalog.organization.slug}-plan-de-apertura-institucional"
-      dataset.title = 'Plan de Apertura Institucional'
+      dataset.title = "Plan de Apertura Institucional de #{@catalog.organization.title}"
       dataset.description = "Plan de Apertura Institucional de #{@catalog.organization.title}"
       dataset.keyword = 'plan-de-apertura'
       dataset.modified = Time.current.iso8601

--- a/spec/models/opening_plan_dataset_generator.rb
+++ b/spec/models/opening_plan_dataset_generator.rb
@@ -26,5 +26,12 @@ describe OpeningPlanDatasetGenerator do
 
       expect(dataset_identifier).to eql(expected_identifier)
     end
+
+    it 'should contain a dataset containing the organization name in the title' do
+      dataset_title = @catalog.datasets.last.title
+      expected_title = "Plan de Apertura Institucional de #{@catalog.organization.title}"
+
+      expect(dataset_title).to eql(expected_title)
+    end
   end
 end

--- a/spec/models/opening_plan_dataset_generator.rb
+++ b/spec/models/opening_plan_dataset_generator.rb
@@ -33,5 +33,12 @@ describe OpeningPlanDatasetGenerator do
 
       expect(dataset_title).to eql(expected_title)
     end
+
+    it 'should contain a distribution containing the organization name in the title' do
+      distribution_title = @catalog.datasets.last.distributions.last.title
+      expected_title = "Plan de Apertura Institucional de #{@catalog.organization.title}"
+
+      expect(distribution_title).to eql(expected_title)
+    end
   end
 end


### PR DESCRIPTION
### Changelog

* Agrega el nombre de la organización en el campo `title` del dataset.
* Agrega el nombre de la organización en el campo `title` de la distribución del dataset.

### How to test

1. Subir un inventario de datos
1. Publicar el plan de apertura
1. Editar el conjunto de datos del inventario

### Deploy

En una sesión de rails console, correr el siguiente script:

https://gist.github.com/babasbot/7acf77f13d16a6360c08

Closes #672

![captura de pantalla 2015-10-26 a las 2 32 28 p m](https://cloud.githubusercontent.com/assets/764518/10741663/8af9b40c-7bee-11e5-9d0c-254f3ec612c8.png)
![captura de pantalla 2015-10-26 a las 2 33 17 p m](https://cloud.githubusercontent.com/assets/764518/10741664/8b35e328-7bee-11e5-8e67-b4d17290ed48.png)
