### PR TITLE
Upsert Dataset del Plan de Apertura

### DIFF
--- a/app/controllers/opening_plan_controller.rb
+++ b/app/controllers/opening_plan_controller.rb
@@ -81,7 +81,7 @@ class OpeningPlanController < ApplicationController
   end
 
   def generate_opening_plan_dataset
-    OpeningPlanDatasetGenerator.new(@organization.catalog).generate unless opening_plan_dataset?
+    OpeningPlanDatasetGenerator.new(@organization.catalog).generate
   end
 
   def generate_catalog_datasets

--- a/app/models/opening_plan_dataset_generator.rb
+++ b/app/models/opening_plan_dataset_generator.rb
@@ -6,13 +6,42 @@ class OpeningPlanDatasetGenerator
   end
 
   def generate
-    dataset = build_dataset
-    build_distribution(dataset)
-    build_sector(dataset) if @catalog.organization.sectors.present?
-    @catalog.save
+    if opening_plan_dataset.present?
+      update_dataset_and_distribution
+    else
+      create_dataset_and_distribution
+    end
   end
 
   private
+
+  def update_dataset_and_distribution
+    update_dataset
+    update_distribution
+  end
+
+  def update_dataset
+    dataset = opening_plan_dataset
+    dataset.modified = Time.current.iso8601
+    dataset.save
+  end
+
+  def update_distribution
+    distribution = opening_plan_dataset.distributions.first
+    distribution.modified = Time.current.iso8601
+    distribution.save
+  end
+
+  def create_dataset_and_distribution
+    dataset = build_dataset
+    build_distribution(dataset)
+    build_sector(dataset) if @catalog.organization.sectors.present?
+    dataset.save
+  end
+
+  def opening_plan_dataset
+    @catalog.datasets.where("identifier LIKE '#{@catalog.organization.slug}-plan-de-apertura-institucional'").last
+  end
 
   def build_dataset
     @catalog.datasets.build do |dataset|

--- a/spec/models/opening_plan_dataset_generator.rb
+++ b/spec/models/opening_plan_dataset_generator.rb
@@ -1,44 +1,73 @@
 require 'spec_helper'
 
 describe OpeningPlanDatasetGenerator do
-  before(:each) do
-    @catalog = create(:catalog)
-  end
-
   describe '#generate' do
+    let(:catalog) { create(:catalog) }
+
     before(:each) do
-      OpeningPlanDatasetGenerator.new(@catalog).generate
+      OpeningPlanDatasetGenerator.new(catalog).generate
     end
 
-    it 'should generate a dataset' do
-      expect(@catalog.datasets.count).to eql(1)
+    context 'with a new opening plan' do
+      it 'should generate a dataset' do
+        expect(catalog.datasets.count).to eql(1)
+      end
+
+      it 'should generate a dataset with one distribution' do
+        dataset = catalog.datasets.last
+        expect(dataset.distributions.count).to eql(1)
+      end
+
+      it 'should contain a dataset with an identifier containing the organization slug' do
+        organization_slug = catalog.organization.slug
+        dataset_identifier = catalog.datasets.last.identifier
+        expected_identifier = "#{organization_slug}-plan-de-apertura-institucional"
+
+        expect(dataset_identifier).to eql(expected_identifier)
+      end
+
+      it 'should contain a dataset containing the organization name in the title' do
+        dataset_title = catalog.datasets.last.title
+        expected_title = "Plan de Apertura Institucional de #{catalog.organization.title}"
+
+        expect(dataset_title).to eql(expected_title)
+      end
+
+      it 'should contain a distribution containing the organization name in the title' do
+        distribution_title = catalog.datasets.last.distributions.last.title
+        expected_title = "Plan de Apertura Institucional de #{catalog.organization.title}"
+
+        expect(distribution_title).to eql(expected_title)
+      end
     end
 
-    it 'should generate a dataset with one distribution' do
-      dataset = @catalog.datasets.last
-      expect(dataset.distributions.count).to eql(1)
-    end
+    context 'updating an existing opening plan' do
+      before(:each) do
+        @old_dataset = catalog.datasets.first.deep_clone(include: [:distributions])
+        Timecop.travel(Faker::Date.forward)
+        OpeningPlanDatasetGenerator.new(catalog).generate
+        @new_dataset = catalog.datasets.first.deep_clone(include: [:distributions])
+      end
 
-    it 'should contain a dataset with an identifier containing the organization slug' do
-      organization_slug = @catalog.organization.slug
-      dataset_identifier = @catalog.datasets.last.identifier
-      expected_identifier = "#{organization_slug}-plan-de-apertura-institucional"
+      after(:each) do
+        Timecop.return
+      end
 
-      expect(dataset_identifier).to eql(expected_identifier)
-    end
+      it 'should not create a new dataset' do
+        expect(catalog.datasets.count).to eql(1)
+      end
 
-    it 'should contain a dataset containing the organization name in the title' do
-      dataset_title = @catalog.datasets.last.title
-      expected_title = "Plan de Apertura Institucional de #{@catalog.organization.title}"
+      it 'should update the modified field from the existing dataset' do
+        old_dataset_modified = @old_dataset.modified
+        new_dataset_modified = @new_dataset.modified
+        expect(new_dataset_modified).to be > old_dataset_modified
+      end
 
-      expect(dataset_title).to eql(expected_title)
-    end
-
-    it 'should contain a distribution containing the organization name in the title' do
-      distribution_title = @catalog.datasets.last.distributions.last.title
-      expected_title = "Plan de Apertura Institucional de #{@catalog.organization.title}"
-
-      expect(distribution_title).to eql(expected_title)
+      it 'should update the modified field from the existing distribution' do
+        old_distribution_modified = @old_dataset.distributions.first.modified
+        new_distribution_modified = @new_dataset.distributions.first.modified
+        expect(new_distribution_modified).not_to eql(old_distribution_modified)
+      end
     end
   end
 end


### PR DESCRIPTION
### Changelog

* Al actualizar el plan de apertura no se duplica el dataset del plan.

### How to test

1. Sube un inventario de datos.
1. Publica un plan de apertura.
1. Edita el plan de apertura.
1. Verifica que el conjunto de datos del plan de apertura no este duplicado.

Closes #643 
