### PR TITLE
Fix API catálogos

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -11,8 +11,10 @@ module Api
       end
 
       def catalogs
-        @catalogs_urls = Organization.with_catalog.map { |org| organization_catalog_url(:slug => org.slug, :host => request.host, :format => :json)}
-        render :json => @catalogs_urls, root: false
+        @catalogs_urls = Organization.all.select do |organization|
+          organization.catalog.present? && organization.catalog.distributions.map(&:published?).any?
+        end
+        render json: @catalogs_urls, root: false
       end
 
       def organizations

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -19,7 +19,6 @@ class Organization < ActiveRecord::Base
   accepts_nested_attributes_for :opening_plans, allow_destroy: true
   accepts_nested_attributes_for :organization_sectors, allow_destroy: true
 
-  scope :with_catalog, -> { joins(:catalog).where("catalogs.published = 't'").uniq }
   scope :title_sorted, -> { order("organizations.title ASC") }
   scope :sector, -> slug { joins(:sectors).where('sectors.slug = ?', slug) }
   scope :gov_type, -> gov_type { where('gov_type = ?', Organization.gov_types[gov_type]) }

--- a/spec/requests/data_catalog_management_spec.rb
+++ b/spec/requests/data_catalog_management_spec.rb
@@ -26,8 +26,11 @@ feature 'data catalog management' do
   end
 
   scenario 'can see all the catalogs available through the api' do
-    create(:catalog)
-    create(:catalog, :unpublished)
+    catalog = create(:catalog, :datasets)
+    dataset = create(:dataset, catalog: catalog)
+    distribution = create(:distribution, dataset: dataset)
+    distribution.update_column(:state, 'published')
+
     get '/api/v1/organizations/catalogs.json'
     json_response = JSON.parse(response.body)
     json_response.size.should == 1


### PR DESCRIPTION
### Changelog

* La API de los catálogos solo muestra las ligas de los catálogos con un dataset publicado.

### How to test

1. Publica un inventario de datos
1. Publica un plan de apertura
1. Publica un inventario de datos
1. Publica un dataset.
1. `GET /api/v1/catalogs`

Closes #690 