### PR TITLE
Fix Opening Plan

### DIFF
--- a/app/controllers/opening_plan_controller.rb
+++ b/app/controllers/opening_plan_controller.rb
@@ -10,9 +10,7 @@ class OpeningPlanController < ApplicationController
 
   def new
     @organization = current_organization
-    cloned_organization = @organization.deep_clone :include => [:opening_plans]
-    @organization.opening_plans = []
-    build_opening_plan_from_inventory(cloned_organization.opening_plans) unless current_inventory.nil?
+    build_opening_plan_from_inventory(@organization.opening_plans) unless current_inventory.nil?
   end
 
   def create
@@ -41,6 +39,7 @@ class OpeningPlanController < ApplicationController
 
   def build_opening_plan_from_inventory(current_plan)
     current_inventory.datasets.each do |element|
+      next if current_plan.map(&:name).include?(element.dataset_title)
       build_opening_plans(element, current_plan) unless element.private?
     end
   end
@@ -49,15 +48,6 @@ class OpeningPlanController < ApplicationController
     @organization.opening_plans.build do |plan|
       plan.name = element.dataset_title
       plan.publish_date = element.publish_date
-
-      current_plan.each do |ds|
-        if element.dataset_title == ds.name
-          plan.description = ds.description
-          plan.accrual_periodicity = ds.accrual_periodicity
-          plan.publish_date = ds.publish_date
-        end
-      end
-
     end
   end
 

--- a/spec/features/user_updates_opening_plan_spec.rb
+++ b/spec/features/user_updates_opening_plan_spec.rb
@@ -76,6 +76,16 @@ feature User, 'updates opening plan:' do
     expect(catalog_with_no_duplicated_datasets).to be
   end
 
+  scenario "and doesn't deletes the previous opening plan" do
+    opening_plan = @organization.opening_plans.first
+    click_link 'Plan de Apertura'
+    click_link 'Actualizar Plan de Apertura'
+    click_link 'Plan de Apertura'
+
+    expect(page).to have_content opening_plan.name
+    expect(page).to have_content opening_plan.description
+  end
+
   def given_organization_inventory_element_with(name)
     inventory = @organization.inventories.last
     inventory.inventory_elements << (create :inventory_element, dataset_title: name)


### PR DESCRIPTION
### Changelog

* Al actualizar el plan de apertura y no guardarlo, no se borra el plan de apertura anterior.

### How to test

* [user_updates_opening_plan_spec.rb#L79](https://github.com/mxabierto/adela/blob/86dfb78d159ac85558c74e7ef2b70775dd4a3b67/spec/features/user_updates_opening_plan_spec.rb#L79)

Closes #697 