### PR TITLE
Fix dataset tags

### DIFF
--- a/app/serializers/dataset_serializer.rb
+++ b/app/serializers/dataset_serializer.rb
@@ -11,7 +11,7 @@ class DatasetSerializer < ActiveModel::Serializer
       name: object.publisher,
       mbox: object.mbox
     }
-    data[:keyword] = object.keywords.split(',')
+    data[:keyword] = object.keywords.split(',').map(&:squish)
     data[:landingPage] = object.landing_page
     data
   end

--- a/spec/requests/data_catalog_management_spec.rb
+++ b/spec/requests/data_catalog_management_spec.rb
@@ -52,4 +52,15 @@ feature 'data catalog management' do
     json_response['dataset'].last.keys.sort.should eq(dcat_dataset_keys.sort)
     json_response['dataset'].last['distribution'].last.keys.sort.should eq(dcat_distribution_keys.sort)
   end
+
+  scenario 'removes linebreaks from keywods' do
+    catalog = create(:catalog, organization: @organization)
+    dataset = create(:dataset, catalog: catalog, keyword: "foo\n, bar\r\n")
+    distribution = create(:distribution, dataset: dataset)
+    distribution.update_column(:state, 'published')
+
+    get "/#{@organization.slug}/catalogo.json"
+    json_response = JSON.parse(response.body)
+    json_response['dataset'][0]['keyword'].sort == %w(bar foo)
+  end
 end


### PR DESCRIPTION
### Changelog

* Elimina los saltos de linea `\r\n` de los tags de un dataset.

### How to test

1. Publicar un inventario
1. Publicar un plan de apertura
1. Editar un conjunto del catalogo, dando enter en los tags.

See [`data_catalog_management_spec.rb`](https://github.com/mxabierto/adela/compare/fix-datasets-tags-%23698?expand=1#diff-365832299b19f3c72c9c260fdaaa18afR58)

Closes #698 