### PR TITLE
Columna Publicar

### DIFF
--- a/app/views/opening_plan/new.html.haml
+++ b/app/views/opening_plan/new.html.haml
@@ -22,7 +22,7 @@
         %table.table.table-striped
           %thead
             %tr
-              %th
+              %th ¿Publicar?
               %th.col-md-4 Nombre del conjunto
               %th.col-md-4 Descripci&oacute;n
               %th Acceso

--- a/app/views/opening_plan/new.html.haml
+++ b/app/views/opening_plan/new.html.haml
@@ -32,7 +32,7 @@
             - @organization.opening_plans.each do |plan|
               = f.fields_for :opening_plans, plan do |builder|
                 %tr
-                  %th= builder.check_box :_destroy, { checked: true, class: 'validable' }, '0', '1'
+                  %th.text-center= builder.check_box :_destroy, { checked: true, class: 'validable' }, '0', '1'
                   %th
                     = builder.hidden_field :name, readonly: true, required: true
                     = plan.name


### PR DESCRIPTION
### Changelog

* Se agrega la titulo a la columna publicar (de los checkboxes) en plan de apertura.
* Se centran los checkboxes del plan de apertura.

### How to test

1. Publicar un inventario de datos.
1. Publicar un plan de apertura.

Closes #414 

![captura de pantalla 2015-11-11 a las 11 55 36 p m](https://cloud.githubusercontent.com/assets/764518/11111672/de91f20c-88d0-11e5-8bf7-006b2bacb743.png)
