### PR TITLE
Updates the dataset modified with the latest distribution modified date

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -4,6 +4,7 @@ class Distribution < ActiveRecord::Base
 
   before_save :fix_distribution
   before_save :break_distibution
+  after_commit :update_dataset_metadata
 
   state_machine initial: :broke do
     state :broke
@@ -34,5 +35,10 @@ class Distribution < ActiveRecord::Base
     fields.each do |field|
       warnings.add(field) if send(field).blank?
     end
+  end
+
+  def update_dataset_metadata
+    last_modified_distribution = dataset.distributions.map(&:modified).sort.last
+    dataset.update(modified: last_modified_distribution)
   end
 end

--- a/spec/helpers/datasets_helper_spec.rb
+++ b/spec/helpers/datasets_helper_spec.rb
@@ -16,6 +16,7 @@ describe DatasetsHelper do
       create(:distribution, :broke, dataset: dataset)
       create(:distribution, :validated, dataset: dataset)
       create(:distribution, :published, dataset: dataset)
+      dataset.reload
 
       distributions = helper.documented_distributions(dataset)
       expect(distributions.count).to eq(2)

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -43,4 +43,14 @@ describe Distribution do
     let(:distribution) { create(:distribution, modified: nil) }
     it_behaves_like 'a non compliant distribution'
   end
+
+  context 'after save' do
+    let(:dataset) { create(:dataset, modified: Date.yesterday) }
+    let(:distribution) { build(:distribution, dataset: dataset, modified: Date.today) }
+
+    it 'should update the dataset modified with the latest distribution modified date' do
+      distribution.save
+      expect(dataset.modified).to eq(distribution.modified)
+    end
+  end
 end


### PR DESCRIPTION
### Changelog

* Al modificar `distribution.modified` de un recurso, su `dataset.modified` toma la fecha más reciente de los recursos.

### How to test

1. Ver [spec](https://github.com/mxabierto/adela/blob/ff3debba0dc9f0c3d8bbb39c01b00650d3acc664/spec/models/distribution_spec.rb#L51).

Closes #509 