### PR TITLE
Adds the organization gov_type to dataset keywords

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -13,12 +13,16 @@ class Dataset < ActiveRecord::Base
   end
 
   def keywords
-    "#{keyword},#{sectors}".chomp(',').lchomp(',').downcase.strip
+    "#{keyword},#{gov_type},#{sectors}".chomp(',').lchomp(',').downcase.strip
   end
 
   private
 
   def sectors
     catalog.organization.sectors.map(&:slug).join(',')
+  end
+
+  def gov_type
+    catalog.organization.gov_type
   end
 end

--- a/spec/requests/data_catalog_management_spec.rb
+++ b/spec/requests/data_catalog_management_spec.rb
@@ -63,4 +63,16 @@ feature 'data catalog management' do
     json_response = JSON.parse(response.body)
     json_response['dataset'][0]['keyword'].sort == %w(bar foo)
   end
+
+  scenario 'dataset keywords contain the organization gov_type' do
+    @organization = create(:organization, :federal)
+    catalog = create(:catalog, organization: @organization)
+    dataset = create(:dataset, catalog: catalog)
+    distribution = create(:distribution, dataset: dataset)
+    distribution.update_column(:state, 'published')
+
+    get "/#{@organization.slug}/catalogo.json"
+    json_response = JSON.parse(response.body)
+    json_response['dataset'][0]['keyword'].should include('federal')
+  end
 end


### PR DESCRIPTION
### Changelog

* Agrega el `gov_type` al keyword del dataset

### How to test

1. Crea una organización con un gov_type
1. Carga un inventario de datos
1. Publica un plan de apertura
1. Publica el catálogo de datos de la organización
1. `GET /:slug:/catalogo.json`

Closes #702 