### PR TITLE
Updates the opening plan dataset metadata

### DIFF
--- a/app/models/opening_plan_dataset_generator.rb
+++ b/app/models/opening_plan_dataset_generator.rb
@@ -72,7 +72,8 @@ class OpeningPlanDatasetGenerator
       distribution.description = "Plan de Apertura Institucional de #{@catalog.organization.title}"
       distribution.download_url = "http://adela.datos.gob.mx/plan-de-apertura/#{@catalog.organization.slug}/export.csv"
       distribution.media_type = 'text/csv'
-      distribution.temporal = Time.current.year
+      distribution.temporal = "#{Date.new(2015, 9, 25)}/#{Date.new(2016, 9, 26)}"
+      distribution.modified = Date.today
     end
   end
 

--- a/spec/models/opening_plan_dataset_generator_spec.rb
+++ b/spec/models/opening_plan_dataset_generator_spec.rb
@@ -18,6 +18,12 @@ describe OpeningPlanDatasetGenerator do
         expect(dataset.distributions.count).to eql(1)
       end
 
+      it 'should generate a dataset with a validated distribution' do
+        dataset = catalog.datasets.last
+        distribution = dataset.distributions.last
+        expect(distribution.state).to eql('validated')
+      end
+
       it 'should contain a dataset with an identifier containing the organization slug' do
         organization_slug = catalog.organization.slug
         dataset_identifier = catalog.datasets.last.identifier


### PR DESCRIPTION
### Changelog

* Se modifica el metadato temporal del dataset del plan de apertura a `2015-09-25T00:00:00+00:00/2016-09-25T00:00:00+00:00`.
* Se agrega el metadato modified a `Date.today`.

# How to Test

1. Sube un inventario de datos.
1. Publica un plan de apertura.
1. Verifica que el dataset del plan de apertura este listo para publicar.

Closes #653 

![pr](https://cloud.githubusercontent.com/assets/764518/11631890/e99eb0e2-9cc9-11e5-9f1d-c87e1ba3c1aa.gif)
