### PR TITLE
Patch v2.0.x

### DIFF
--- a/app/controllers/catalogs_controller.rb
+++ b/app/controllers/catalogs_controller.rb
@@ -15,6 +15,7 @@ class CatalogsController < ApplicationController
     @datasets = catalog_params['distribution_ids'].map do |id|
       Distribution.find(id).dataset
     end
+    @datasets.uniq!
   end
 
   def publish

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -3,10 +3,6 @@ module DatasetsHelper
     ISO8601_DEFAULTS['accrual_periodicity'].invert[accrual_periodicity]
   end
 
-  def documented_distributions?(dataset)
-    dataset.distributions.select(&:documented?).present?
-  end
-
   def published_distributions?(dataset)
     dataset.distributions.select(&:published?).present?
   end

--- a/app/views/catalogs/check.html.haml
+++ b/app/views/catalogs/check.html.haml
@@ -9,7 +9,6 @@
 
     = form_for current_organization.catalog, url: publish_catalog_path(current_organization.catalog), method: :put do |f|
       - @datasets.each do |dataset|
-        - next unless documented_distributions?(dataset)
         %h5.subtitle= dataset.title
         .section
           .row

--- a/app/views/distributions/edit.html.haml
+++ b/app/views/distributions/edit.html.haml
@@ -35,7 +35,7 @@
               %i.fa.fa-calendar
 
       = f.button 'Guardar avance', type: 'submit', class: 'btn btn-primary'
-      = link_to 'Cancelar', edit_dataset_path, class: 'btn btn-primary'
+      = link_to 'Cancelar', edit_dataset_path(@distribution.dataset), class: 'btn btn-primary'
 
 :javascript
   $(function () {


### PR DESCRIPTION
### Fixes
* **Closes #699:** No funciona el botón de Cancelar en la edición del recurso
* **Closes #725:** En la vista previa a la publicación del catálogo se repiten los conjuntos y recursos.
* **Closes #734:** Conjuntos duplicados al validar y publicar.
