### PR TITLE
Historico del Plan de Apertura

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.3.0
 env:
   - DB=postgresql
+addons:
+  postgresql: 9.3
 bundler_args: --without development
 script:
   - export RAILS_ENV=test

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,6 +1,6 @@
 # TODO: needs refactoring
 class OrganizationsController < ApplicationController
-  before_action :authenticate_user!, except: [:catalog, :search, :opening_plan]
+  before_action :authenticate_user!, except: [:catalog, :search, :opening_plans]
 
   # TODO: move action to home#dashboard
   def show
@@ -21,10 +21,11 @@ class OrganizationsController < ApplicationController
   end
 
   # TODO: move action to a controller under the API namespace
-  def opening_plan
+  def opening_plans
     @organization = Organization.friendly.find(params[:slug])
+    @opening_plan = OpeningPlan.new(catalog: @organization.catalog)
     respond_to do |format|
-      format.json { render json: @organization, serializer: OrganizationOpeningPlanSerializer, root: false }
+      format.json { render json: @opening_plan, root: false }
     end
   end
 

--- a/app/models/catalog.rb
+++ b/app/models/catalog.rb
@@ -14,6 +14,10 @@ class Catalog < ActiveRecord::Base
     end
   end
 
+  def opening_plan_datasets
+    datasets.where(public_access: true, published: true, editable: true)
+  end
+
   def catalog_datasets
     datasets.where(public_access: true, published: true).select do |dataset|
       dataset.valid?(:opening_plan)

--- a/app/models/catalog.rb
+++ b/app/models/catalog.rb
@@ -8,7 +8,7 @@ class Catalog < ActiveRecord::Base
 
   accepts_nested_attributes_for :datasets
 
-  def opening_plan_datasets
+  def inventory_datasets
     datasets.where(public_access: true, editable: true).select do |dataset|
       dataset.valid?(:inventory)
     end

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -38,6 +38,7 @@ class Distribution < ActiveRecord::Base
   end
 
   def update_dataset_metadata
+    return unless dataset
     last_modified_distribution = dataset.distributions.map(&:modified).compact.sort.last
     dataset.update(modified: last_modified_distribution)
   end

--- a/app/models/opening_plan.rb
+++ b/app/models/opening_plan.rb
@@ -1,0 +1,4 @@
+class OpeningPlan
+  include ActiveModel::Model
+  attr_accessor :catalog
+end

--- a/app/models/opening_plan_log.rb
+++ b/app/models/opening_plan_log.rb
@@ -1,0 +1,3 @@
+class OpeningPlanLog < ActiveRecord::Base
+  belongs_to :organization
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,6 +10,7 @@ class Organization < ActiveRecord::Base
   has_many :users
   has_many :activity_logs
   has_many :inventories
+  has_many :opening_plan_logs, dependent: :destroy
   has_many :organization_sectors, dependent: :destroy
   has_many :sectors, through: :organization_sectors
 

--- a/app/serializers/loggers/opening_plan_serializer.rb
+++ b/app/serializers/loggers/opening_plan_serializer.rb
@@ -1,0 +1,12 @@
+class Loggers::OpeningPlanSerializer < ActiveModel::Serializer
+  attributes *Dataset.column_names
+
+  def attributes
+    {
+      title: title,
+      description: description,
+      accrual_periodicity: accrual_periodicity,
+      publish_date: publish_date.strftime('%F')
+    }
+  end
+end

--- a/app/serializers/opening_plan/dataset_serializer.rb
+++ b/app/serializers/opening_plan/dataset_serializer.rb
@@ -1,0 +1,28 @@
+class OpeningPlan::DatasetSerializer < ActiveModel::Serializer
+  attributes *Dataset.column_names
+
+  def attributes
+    {
+      name: title,
+      description: description,
+      publish_date: publish_date.strftime('%F'),
+      officials: [admin_official, liaison_official]
+    }
+  end
+
+  def admin_official
+    {
+      type: 'Administrador de Datos',
+      name: object.catalog.organization.administrator&.user&.name.to_s,
+      email: object.catalog.organization.administrator&.user&.email.to_s,
+    }
+  end
+
+  def liaison_official
+    {
+      type: 'Enlace Institucional',
+      name: object.catalog.organization.liaison&.user&.name.to_s,
+      email: object.catalog.organization.liaison&.user&.email.to_s,
+    }
+  end
+end

--- a/app/serializers/opening_plan_serializer.rb
+++ b/app/serializers/opening_plan_serializer.rb
@@ -1,3 +1,15 @@
 class OpeningPlanSerializer < ActiveModel::Serializer
-  attributes :vision, :name, :description, :publish_date
+  has_many :opening_plans, serializer: OpeningPlan::DatasetSerializer
+
+  def attributes
+    {
+      title: "Plan de Apertura de #{object.catalog.organization.title}",
+      language: 'es',
+      license: 'http://datos.gob.mx/libreusomx/',
+    }
+  end
+
+  def opening_plans
+    object.catalog.opening_plan_datasets
+  end
 end

--- a/app/views/opening_plans/index.html.haml
+++ b/app/views/opening_plans/index.html.haml
@@ -21,7 +21,7 @@
             %th Frecuencia con la que actualizan
             %th Confirmar fecha de Publicaci&oacute;n
         %tbody
-          - current_organization.catalog.datasets.where(public_access: true, published: true, editable: true).each do |dataset|
+          - current_organization.catalog.opening_plan_datasets.each do |dataset|
             %tr
               %th= dataset.title
               %th= dataset.description

--- a/app/views/opening_plans/new.html.haml
+++ b/app/views/opening_plans/new.html.haml
@@ -22,7 +22,7 @@
               %th Frecuencia con la que actualizan
               %th Confirmar fecha de Publicaci&oacute;n
           %tbody
-            - current_organization.catalog.opening_plan_datasets.each do |dataset|
+            - current_organization.catalog.inventory_datasets.each do |dataset|
               = f.fields_for :datasets, dataset do |builder|
                 %tr
                   %th.text-center= builder.check_box :published, { checked: true, class: 'validable' }

--- a/db/migrate/20160303180313_create_opening_plan_logs.rb
+++ b/db/migrate/20160303180313_create_opening_plan_logs.rb
@@ -1,0 +1,10 @@
+class CreateOpeningPlanLogs < ActiveRecord::Migration
+  def change
+    create_table :opening_plan_logs do |t|
+      t.references :organization, index: true, foreign_key: true
+      t.json :opening_plan
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160126181226) do
+ActiveRecord::Schema.define(version: 20160303180313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,6 +117,15 @@ ActiveRecord::Schema.define(version: 20160126181226) do
   add_index "liaisons", ["organization_id"], name: "index_liaisons_on_organization_id", using: :btree
   add_index "liaisons", ["user_id"], name: "index_liaisons_on_user_id", using: :btree
 
+  create_table "opening_plan_logs", force: :cascade do |t|
+    t.integer  "organization_id"
+    t.json     "opening_plan"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "opening_plan_logs", ["organization_id"], name: "index_opening_plan_logs_on_organization_id", using: :btree
+
   create_table "organization_sectors", force: :cascade do |t|
     t.integer  "sector_id"
     t.integer  "organization_id"
@@ -189,4 +198,5 @@ ActiveRecord::Schema.define(version: 20160126181226) do
 
   add_index "users_roles", ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id", using: :btree
 
+  add_foreign_key "opening_plan_logs", "organizations"
 end

--- a/spec/factories/catalogs.rb
+++ b/spec/factories/catalogs.rb
@@ -19,5 +19,18 @@ FactoryGirl.define do
         create_list(:dataset, evaluator.datasets_count, :distributions, catalog: catalog)
       end
     end
+
+    factory :catalog_with_opening_plan do
+      transient do
+        datasets_count { Faker::Number.between(1, 8) }
+      end
+
+      after(:create) do |catalog, evaluator|
+        create_list(
+          :dataset, evaluator.datasets_count, :distributions,
+          catalog: catalog, public_access: true, published: true, editable: true
+        )
+      end
+    end
   end
 end

--- a/spec/factories/opening_plan_logs.rb
+++ b/spec/factories/opening_plan_logs.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :opening_plan_log do
+    organization
+  end
+end

--- a/spec/models/opening_plan_log_spec.rb
+++ b/spec/models/opening_plan_log_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+
+RSpec.describe OpeningPlanLog, type: :model do
+end

--- a/spec/requests/opening_plan_management_spec.rb
+++ b/spec/requests/opening_plan_management_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 
 feature 'opening plan management' do
-  it 'returns the organization opening plan', skip: true do
+  let(:opening_plan) { create(:catalog_with_opening_plan) }
+
+  it 'returns the organization opening plan' do
     get "/#{opening_plan.organization.slug}/plan.json"
     expect(response).to match_response_schema('opening_plan')
   end

--- a/spec/support/api/schemas/opening_plan.json
+++ b/spec/support/api/schemas/opening_plan.json
@@ -15,9 +15,6 @@
       "items": {
         "type": "object",
         "properties": {
-          "vision": {
-            "type": "string"
-          },
           "name": {
             "type": "string"
           },
@@ -33,13 +30,24 @@
               {
                 "type": "object",
                 "properties": {
-                  "kind": {
+                  "type": {
                     "type": "string"
                   },
                   "name": {
                     "type": "string"
                   },
-                  "position": {
+                  "email": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "name": {
                     "type": "string"
                   },
                   "email": {


### PR DESCRIPTION
### Changelog
* **Closes #527:** Se guarda el historico del plan de apertura de una organización.
* Se arregla la API del plan de Apertura

### How to Test
1. Publicar un plan de apertura
1. Verificar el log del plan de apertura en una sesion de `rails console` con `OpeningPlanLog.last`
1. Consultar la API del plan de apertura en `GET /:slug:/plan.json`

<img width="1552" alt="captura de pantalla 2016-03-08 a las 7 47 11 a m" src="https://cloud.githubusercontent.com/assets/764518/13603346/3010505a-e502-11e5-9858-0bb7db2131bf.png">