### PR TITLE
Campos Mandatorios en el Inventario

### DIFF
--- a/app/assets/javascripts/datasets.js
+++ b/app/assets/javascripts/datasets.js
@@ -4,10 +4,12 @@ $(function () {
 
         setPrivateMandatoryFields = function () {
             $('#dataset_publish_date').removeAttr('required');
+            $("label[for='dataset_publish_date']").parent().removeClass('required');
         };
 
         setPublicMandatoryFields = function () {
             $('#dataset_publish_date').attr('required', 'required');
+            $("label[for='dataset_publish_date']").parent().addClass('required');
         };
 
         publicDataset = ($('#dataset_public_access').val() === "true");

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -17,6 +17,12 @@
   }
 }
 
+.form-group.required .control-label:after {
+  content: " *";
+  font-weight: 700;
+  color: #de6c6c;
+}
+
 .inline {
   display: inline-block !important;
 }

--- a/app/views/inventories/datasets/edit.html.haml
+++ b/app/views/inventories/datasets/edit.html.haml
@@ -4,17 +4,20 @@
     %h5.subtitle Inventario de datos
     %h5.subtitle Editar Conjunto de Datos
     = form_for [:inventories, @dataset] do |f|
-      .form-group
-        = f.label :title
+      .form-group.required
+        = f.label :title, class: 'control-label'
         = f.text_field :title, required: true, class: 'form-control'
-      .form-group
-        = f.label :contact_position
+      .form-group.required
+        = f.label :contact_position, class: 'control-label'
         = f.text_field :contact_position, required: true, class: 'form-control'
-      .form-group
-        = f.label :public_access
+      .form-group.required
+        = f.label :public_access, class: 'control-label'
         = f.select :public_access, [['Público', true], ['Privado', false]], {}, required: true, class: 'form-control'
       .form-group
-        = f.label :publish_date
+        = f.label :publish_date, class: 'control-label'
         = f.text_field :publish_date, class: 'datepicker form-control'
+      .form-group.required
+        %label.control-label
+          Campos obligatorios
       .form-group
         = f.button 'Guardar', type: 'submit', class: 'btn btn-primary'

--- a/app/views/inventories/datasets/new.html.haml
+++ b/app/views/inventories/datasets/new.html.haml
@@ -4,31 +4,37 @@
     %h5.subtitle Inventario de datos
     %h5.subtitle Conjunto de Datos
     = nested_form_for [:inventories, Dataset.new] do |f|
-      .form-group
-        = f.label :title
+      .form-group.required
+        = f.label :title, class: 'control-label'
         = f.text_field :title, required: true, class: 'form-control'
-      .form-group
-        = f.label :contact_position
+      .form-group.required
+        = f.label :contact_position, class: 'control-label'
         = f.text_field :contact_position, required: true, class: 'form-control'
-      .form-group
-        = f.label :public_access
+      .form-group.required
+        = f.label :public_access, class: 'control-label'
         = f.select :public_access, [['Público', true], ['Privado', false]], {}, required: true, class: 'form-control'
-      .form-group
-        = f.label :publish_date
+      .form-group.required
+        = f.label :publish_date, class: 'control-label'
         = f.text_field :publish_date, class: 'datepicker form-control'
       = f.fields_for :distributions do |distribution_form|
         %h5.subtitle Recurso
-        .form-group
-          = distribution_form.label :title
+        .form-group.required
+          = distribution_form.label :title, class: 'control-label'
           = distribution_form.text_field :title, required: true, class: 'form-control'
-        .form-group
-          = distribution_form.label :description
+        .form-group.required
+          = distribution_form.label :description, class: 'control-label'
           = distribution_form.text_area :description, required: true, class: 'autosize form-control'
-        .form-group
-          = distribution_form.label :media_type
+        .form-group.required
+          = distribution_form.label :media_type, class: 'control-label'
           = distribution_form.text_field :media_type, required: true, class: 'form-control'
+        .form-group.required
+          %label.control-label
+            Campos obligatorios
         .form-group.pull-right
           = distribution_form.link_to_remove 'Eliminar Recurso', class: 'btn btn-primary'
           = f.button 'Guardar', type: 'submit', class: 'btn btn-primary'
+      .form-group.required
+        %label.control-label
+          Campos obligatorios
       .form-group
         = f.link_to_add "Agregar Recurso", :distributions, class: 'btn btn-primary'

--- a/app/views/inventories/distributions/edit.html.haml
+++ b/app/views/inventories/distributions/edit.html.haml
@@ -4,14 +4,17 @@
     %h5.subtitle Inventario de datos
     %h5.subtitle Editar Recurso
     = form_for [:inventories, @distribution.dataset, @distribution] do |f|
-      .form-group
-        = f.label :title
+      .form-group.required
+        = f.label :title, class: 'control-label'
         = f.text_field :title, required: true, class: 'form-control'
-      .form-group
-        = f.label :description
+      .form-group.required
+        = f.label :description, class: 'control-label'
         = f.text_area :description, required: true, class: 'autosize form-control'
-      .form-group
-        = f.label :media_type
+      .form-group.required
+        = f.label :media_type, class: 'control-label'
         = f.text_field :media_type, required: true, class: 'form-control'
+      .form-group.required
+        %label.control-label
+          Campos obligatorios
       .form-group
         = f.button 'Guardar', type: 'submit', class: 'btn btn-primary'

--- a/app/views/inventories/distributions/new.html.haml
+++ b/app/views/inventories/distributions/new.html.haml
@@ -2,16 +2,19 @@
   .card
     %h3.title Planea
     %h5.subtitle Inventario de datos
-    %h5.subtitle Editar Recurso
+    %h5.subtitle Agregar Recurso
     = form_for [:inventories, @dataset, @distribution] do |f|
-      .form-group
-        = f.label :title
+      .form-group.required
+        = f.label :title, class: 'control-label'
         = f.text_field :title, required: true, class: 'form-control'
-      .form-group
-        = f.label :description
+      .form-group.required
+        = f.label :description, class: 'control-label'
         = f.text_area :description, required: true, class: 'autosize form-control'
-      .form-group
-        = f.label :media_type
+      .form-group.required
+        = f.label :media_type, class: 'control-label'
         = f.text_field :media_type, required: true, class: 'form-control'
+      .form-group.required
+        %label.control-label
+          Campos obligatorios
       .form-group
         = f.button 'Guardar', type: 'submit', class: 'btn btn-primary'


### PR DESCRIPTION
### Changelog
* **Closes #790:** Se agrega un `*` a los campos mandatorios en los formularios del inventario. 

### How to Test
1. Sube un inventario de datos.
1. Agrega un recurso en algun conjunto de datos.
1. Edita un conjunto de datos.
1. Edita algun recurso de un conjunto de datos.

<img width="1552" alt="captura de pantalla 2016-03-08 a las 9 56 36 a m" src="https://cloud.githubusercontent.com/assets/764518/13607602/884fdea2-e516-11e5-9957-01346c13dcc5.png">
