### PR TITLE
Highlight Header Menus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'state_machines-activerecord'
 gem 'autosize-rails'
 gem 'babosa'
 gem 'momentjs-rails'
+gem 'active_link_to'
 
 group :development, :test do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_link_to (1.0.3)
+      actionpack
     active_model_serializers (0.9.3)
       activemodel (>= 3.2)
     active_model_warnings (0.2.0)
@@ -361,6 +363,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_link_to
   active_model_serializers
   active_model_warnings
   autosize-rails

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,11 +1,17 @@
 // Navbar default colors
 $navbar_background_color: $grey_800;
+
 $navbar_default_links_color: #fff;
-$navbar_active_links_color: $cartoon_green;
+$navbar_default_links_hover_color: #adadad;
+
+$navbar_active_links_color: #adadad;
+$navbar_active_links_background: #545454;
+
+$navbar_alt_active_links_color: $cartoon_green;
 
 // Paddings
-$navbar_padding_top: 10px;
-$navbar_padding_bottom: 10px;
+$navbar_padding_top: 0px;
+$navbar_padding_bottom: 20px;
 
 // Margins
 $navbar_margin_bottom: 50px;
@@ -13,13 +19,13 @@ $navbar_margin_bottom: 50px;
 // Avatar
 $navbar_avatar_size: 80px;
 
-
 nav {
   z-index: 1;
 
   margin-bottom: $navbar_margin_bottom !important;
   border: 0 !important;
   border-radius: 0 !important;
+  // font-weight: 300;
 
   span {
     color: $navbar_default_links_color;
@@ -44,18 +50,26 @@ nav {
 #navbar > ul > li > a {
   color: $navbar_default_links_color;
   line-height: $navbar_avatar_size / 2;
+  border-radius: 4px;
+  padding: $navbar_padding_top $navbar_padding_bottom;
+  margin-top: 15px;
 
   &.active {
     color: $navbar_active_links_color;
   }
 
   &:hover {
-    color: $navbar_active_links_color;
+    color: $navbar_default_links_hover_color;
   }
 
   &.dropdown-toggle {
-    color: $navbar_active_links_color;
+    color: $navbar_alt_active_links_color;
   }
+}
+
+#navbar > ul > li.active > a {
+  background-color: $navbar_active_links_color;
+  color: $navbar_active_links_background;
 }
 
 .navbar-default .navbar-nav > .open > a {

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -45,6 +45,10 @@ nav {
   color: $navbar_default_links_color;
   line-height: $navbar_avatar_size / 2;
 
+  &.active {
+    color: $navbar_active_links_color;
+  }
+
   &:hover {
     color: $navbar_active_links_color;
   }

--- a/app/views/layouts/shared/_organization_signed_in_user_menu.html.haml
+++ b/app/views/layouts/shared/_organization_signed_in_user_menu.html.haml
@@ -1,6 +1,9 @@
-%li= link_to 'Inventario de Datos', inventories_path
-%li= link_to 'Plan de Apertura', opening_plans_path
-%li= link_to 'Catálogo de Datos', organization_catalogs_path(current_organization)
+%li
+  = active_link_to 'Inventario de Datos', inventories_path, active: :inclusive
+%li
+  = active_link_to 'Plan de Apertura', opening_plans_path, active: :inclusive
+%li
+  = active_link_to 'Catálogo de Datos', organization_catalogs_path(current_organization), active: [['catalogs', 'datasets', 'distributions'], []]
 %li.dropdown
   %a.dropdown-toggle{ :href => '#', 'data-toggle' => 'dropdown', :role => 'button', 'aria-haspopup' => 'true', 'aria-expanded' => 'false' }
     = image_tag 'adelitas.gif', class: 'avatar'

--- a/app/views/layouts/shared/_organization_signed_in_user_menu.html.haml
+++ b/app/views/layouts/shared/_organization_signed_in_user_menu.html.haml
@@ -1,9 +1,6 @@
-%li
-  = active_link_to 'Inventario de Datos', inventories_path, active: :inclusive
-%li
-  = active_link_to 'Plan de Apertura', opening_plans_path, active: :inclusive
-%li
-  = active_link_to 'Catálogo de Datos', organization_catalogs_path(current_organization), active: [['catalogs', 'datasets', 'distributions'], []]
+= active_link_to 'Inventario de Datos', inventories_path, active: :inclusive, wrap_tag: :li
+= active_link_to 'Plan de Apertura', opening_plans_path, active: :inclusive, wrap_tag: :li
+= active_link_to 'Catálogo de Datos', organization_catalogs_path(current_organization), active: [['catalogs', 'datasets', 'distributions'], []], wrap_tag: :li
 %li.dropdown
   %a.dropdown-toggle{ :href => '#', 'data-toggle' => 'dropdown', :role => 'button', 'aria-haspopup' => 'true', 'aria-expanded' => 'false' }
     = image_tag 'adelitas.gif', class: 'avatar'


### PR DESCRIPTION
### Changelog
* **Closes #783:** Los menus del `nav-bar` se activan dependiendo de la sección donde este el usuario.

### How To Test
1. Navegar por las secciones del Inventario.
1. Navegar por las secciones del Plan de Apertura.
1. Navegar por las secciones del Catalogo.

<img width="1552" alt="captura de pantalla 2016-03-08 a las 4 25 20 p m" src="https://cloud.githubusercontent.com/assets/764518/13618592/9b2bd1aa-e54a-11e5-9df3-cab15ccaa4c0.png">
