### PR TITLE
Elimina sección de actividad reciente del home

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,4 @@
 class HomeController < ApplicationController
   before_action :authenticate_user!, except: :index
 
-  def index
-    @logs = ActivityLog.date_sorted
-  end
 end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -8,20 +8,8 @@
 
   .container
     .row.actions
-      .col-xs-12.col-md-6
-        %p.topic Actividad Reciente
-        %hr
-        - if @logs.any?
-          %ul.recent_activity
-            - @logs.first_block.each_with_index do |activity, index|
-              - if index.even?
-                %li.even #{activity.organization.title} #{I18n.t(activity.message)}
-              - else
-                %li.odd #{activity.organization.title} #{I18n.t(activity.message)}
-        - else
-          %p.bright No hay actividad reciente.
       - if !user_signed_in?
-        .col-xs-12.col-md-6
+        .col-xs-12.col-md-6.col-md-offset-3
           %p.topic Ingresar
           %hr
           = render 'shared/forms/user', resource: User.new, resource_name: :user

--- a/spec/features/user_logs_in_spec.rb
+++ b/spec/features/user_logs_in_spec.rb
@@ -15,7 +15,6 @@ feature User, 'logs in:' do
   scenario "visits root page and sees landing page" do
     visit "/"
     expect(page).to have_text "Con la Administradora de la Apertura, planea, publica, perfecciona y promueve datos abiertos."
-    expect(page).to have_text "Actividad Reciente"
   end
 
   scenario "visits root page and sees log in link" do


### PR DESCRIPTION
fix #778 

## ¿Cómo validar?
1. Entrar al [home de Adela](http://localhost:3000) y validar que solo se muestre el formulario para Ingresar
![screen shot 2016-03-11 at 09 50 59](https://cloud.githubusercontent.com/assets/2633527/13707355/e059a75e-e76e-11e5-8ffa-1ad70bb9df62.png)
