### PR TITLE
Pone los botones del inventario al final de la página

### DIFF
--- a/app/views/inventories/index.html.haml
+++ b/app/views/inventories/index.html.haml
@@ -9,5 +9,7 @@
         = render partial: 'inventories/shared/menus/inventory_actions'
       = render partial: 'inventories/shared/list', locals: { inventory: current_inventory }
       = link_to 'Continua con el Plan de Apertura', new_opening_plan_path, { class: 'btn btn-primary' }
+      = link_to 'Actualizar Inventario', new_inventory_path, { class: 'btn btn-primary' }
+      = link_to 'Descargar Inventario Actual', current_inventory.spreadsheet_file.url, { class: 'btn btn-primary' } 
     - else
       = render 'inventories/shared/form'

--- a/app/views/inventories/shared/menus/_inventory_actions.html.haml
+++ b/app/views/inventories/shared/menus/_inventory_actions.html.haml
@@ -4,10 +4,5 @@
     %span.caret.white
   %ul.dropdown-menu
     %li.dropdown-header
-      Inventario de Datos
-    %li= link_to 'Actualizar', new_inventory_path
-    %li= link_to 'Descargar', current_inventory.spreadsheet_file.url
-    %li.divider{ 'role' => 'separator' }
-    %li.dropdown-header
       Conjunto de Datos
     %li= link_to 'Agregar', new_inventories_dataset_path

--- a/spec/features/user_uploads_inventory_spreadsheet_file_spec.rb
+++ b/spec/features/user_uploads_inventory_spreadsheet_file_spec.rb
@@ -57,10 +57,7 @@ feature User, 'uploads inventory spreadsheet file:' do
     upload_inventory_with_file('inventario_general_de_datos.xlsx')
     within('.navbar') { click_on('Inventario de Datos') }
 
-    within('.btn-group') do
-      click_on('Acciones')
-      click_on('Actualizar')
-    end
+    click_on('Actualizar Inventario')
 
     expect(current_path).to eq(new_inventory_path)
     submit_inventory_form_with_spreadsheet_file('another-inventory-spreadsheet-file.xlsx')
@@ -81,10 +78,7 @@ feature User, 'uploads inventory spreadsheet file:' do
     upload_inventory_with_file('inventario_general_de_datos.xlsx')
     within('.navbar') { click_on('Inventario de Datos') }
 
-    within('.btn-group') do
-      click_on('Acciones')
-      click_on('Actualizar')
-    end
+    click_on('Actualizar Inventario')
 
     expect(current_path).to eq(new_inventory_path)
     submit_inventory_form_with_spreadsheet_file('inventario_general_de_datos_update.xlsx')
@@ -122,10 +116,7 @@ feature User, 'uploads inventory spreadsheet file:' do
     upload_inventory_with_file('inventario_general_de_datos.xlsx')
     within('.navbar') { click_on('Inventario de Datos') }
 
-    within('.btn-group') do
-      click_on('Acciones')
-      click_on('Actualizar')
-    end
+    click_on('Actualizar Inventario')
 
     expect(current_path).to eq(new_inventory_path)
     expect(page).to have_css('#inventory_activity_logs_attributes_0_description')


### PR DESCRIPTION
fix #788 

## ¿Cómo validar?
1. Ingresar a Adela
2. Subir un nuevo inventario de datos  
3. Ir a la sección de Inventario y validar que los botones para descargar y actualizar inventario se muestran hasta abajo
![screen shot 2016-03-11 at 15 28 57](https://cloud.githubusercontent.com/assets/2633527/13716014/059f4e90-e79e-11e5-91c3-1da4c74e8c8f.png)
