### PR TITLE
Actualiza nombre del botón

### DIFF
--- a/app/views/opening_plans/new.html.haml
+++ b/app/views/opening_plans/new.html.haml
@@ -42,7 +42,7 @@
               = log_form.label :description, 'Describe los cambios realizados'
             .form-group
               = log_form.text_area :description, required: true, class: 'autosize form-control'
-        = f.button 'Generar Plan de Apertura', type: 'submit', class: 'btn btn-primary'
+        = f.button 'Guardar Plan de Apertura', type: 'submit', class: 'btn btn-primary'
 
 :javascript
   function updateValidations(event) {

--- a/spec/features/user_manages_opening_plan.rb
+++ b/spec/features/user_manages_opening_plan.rb
@@ -29,7 +29,7 @@ feature User, 'manages catalog:' do
     visit new_opening_plan_path
     fill_in 'catalog_datasets_attributes_0_description', with: 'osom dataset'
     select('anual', from: 'organization[opening_plans_attributes][0][accrual_periodicity]')
-    click_on('Generar Plan de Apertura')
+    click_on('Guardar Plan de Apertura')
     expect(page).to have_text('osom dataset')
     expect(page).to have_text('anual')
     expect(page).to have_text('Descargar Archivo')


### PR DESCRIPTION
fix #794 

## ¿Cómo validar?

1. Ingresar a Adela
2. Subir un inventario
3. Ir a Inventario
4. Dar clic en `Continua con el Plan de Apertura`
5. Validar que el botón diga `Guardar Plan de Apertura`
![screen shot 2016-03-12 at 22 13 51](https://cloud.githubusercontent.com/assets/2633527/13726896/bfc9c996-e8a0-11e5-9a46-1dc5855347fb.png)
