### PR TITLE
Enumera conjuntos del plan de apertura

### DIFF
--- a/app/views/opening_plans/index.html.haml
+++ b/app/views/opening_plans/index.html.haml
@@ -16,13 +16,15 @@
       %table.table.table-striped
         %thead
           %tr
+            %th.text-center #
             %th Nombre del conjunto
             %th Descripci&oacute;n
             %th Frecuencia con la que actualizan
             %th Confirmar fecha de Publicaci&oacute;n
         %tbody
-          - current_organization.catalog.opening_plan_datasets.each do |dataset|
+          - current_organization.catalog.opening_plan_datasets.each_with_index do |dataset, index|
             %tr
+              %th.text-center= index + 1
               %th= dataset.title
               %th= dataset.description
               %th= parse_iso8601(dataset.accrual_periodicity)

--- a/app/views/opening_plans/new.html.haml
+++ b/app/views/opening_plans/new.html.haml
@@ -16,15 +16,17 @@
         %table.table.table-striped
           %thead
             %tr
+              %th.text-center #
               %th ¿Publicar?
               %th.col-md-4 Nombre del conjunto
               %th.col-md-4 Descripci&oacute;n
               %th Frecuencia con la que actualizan
               %th Confirmar fecha de Publicaci&oacute;n
           %tbody
-            - current_organization.catalog.inventory_datasets.each do |dataset|
+            - current_organization.catalog.inventory_datasets.each_with_index do |dataset, index|
               = f.fields_for :datasets, dataset do |builder|
                 %tr
+                  %th.text-center= index + 1
                   %th.text-center= builder.check_box :published, { checked: true, class: 'validable' }
                   %th
                     = builder.hidden_field :title, readonly: true, required: true


### PR DESCRIPTION
### Changelog
* **Closes #795:** Enumera los conjuntos de datos del plan de apertura.

### How to test
1. Genera un plan de apertura

<img width="1552" alt="captura de pantalla 2016-03-13 a las 4 46 54 p m" src="https://cloud.githubusercontent.com/assets/764518/13731964/ec84cf94-e93b-11e5-9987-5b8b27e00be9.png">
<img width="1552" alt="captura de pantalla 2016-03-13 a las 4 46 58 p m" src="https://cloud.githubusercontent.com/assets/764518/13731965/ec8aa838-e93b-11e5-8aaa-d3972a33aafe.png">
