### PR TITLE
Enumera conjuntos del catálogo

### DIFF
--- a/app/views/datasets/index.html.haml
+++ b/app/views/datasets/index.html.haml
@@ -12,6 +12,7 @@
       %table.table.table-striped
         %thead.catalog-header
           %tr
+            %th.text-center #
             %th
               Conjuntos y recursos de datos
               %i.fa.fa-caret-down
@@ -27,8 +28,9 @@
             %th
               Acciones
         %tbody
-          - @catalog.catalog_datasets.sort_by(&:publish_date).each do |dataset|
+          - @catalog.catalog_datasets.sort_by(&:publish_date).each_with_index do |dataset, index|
             %tr.dataset
+              %td.text-center= index + 1
               %td= dataset.title
               %td
               %td= "#{documented_distributions(dataset).count} de #{dataset.distributions.count}"
@@ -36,6 +38,7 @@
               %td.action= link_to 'Editar', edit_dataset_path(dataset)
             - dataset.distributions.each do |distribution|
               %tr.distribution
+                %td
                 %td.nested
                   - if distribution.documented?
                     = check_box_tag('catalog[distribution_ids][]', distribution.id, true, class: 'cell-checkbox little-margin-right')


### PR DESCRIPTION
### Changelog
* **Closes #796:** Se enumeran los conjuntos de datos en el catálogo de datos.

### How to test
1. Sube un inventario de datos
1. Genera un plan de apertura
1. Entra al catálogo de datos

<img width="1552" alt="captura de pantalla 2016-03-13 a las 6 15 56 p m" src="https://cloud.githubusercontent.com/assets/764518/13732441/7e725fbe-e948-11e5-89b0-927dfd13c1e2.png">