### PR TITLE
Asks for confirmation when deleting datasets and distributions

### DIFF
--- a/app/controllers/inventories/datasets_controller.rb
+++ b/app/controllers/inventories/datasets_controller.rb
@@ -3,6 +3,10 @@ class Inventories::DatasetsController < ApplicationController
 
   before_action :authenticate_user!
 
+  def confirm_destroy
+    @dataset = Dataset.find(params[:id])
+  end
+
   private
 
   def create_customization

--- a/app/controllers/inventories/distributions_controller.rb
+++ b/app/controllers/inventories/distributions_controller.rb
@@ -1,6 +1,10 @@
 class Inventories::DistributionsController < ApplicationController
   include DistributionActions
 
+  def confirm_destroy
+    @distribution = Distribution.find(params[:id])
+  end
+
   private
 
   def create_customization

--- a/app/views/inventories/datasets/confirm_destroy.html.haml
+++ b/app/views/inventories/datasets/confirm_destroy.html.haml
@@ -1,0 +1,10 @@
+.container
+  .card
+    %h3.title Planea
+    %h5.subtitle Inventario de datos
+    .card.padding-top.bg--grey
+      %h5.primary.boldish Eliminar Conjunto de Datos
+      %p
+        Al borrar el conjunto <strong>#{@dataset.title}</strong>, se perderán los recursos asociados a el.
+      = link_to 'Eliminar Conjunto de Datos', inventories_dataset_path(@dataset), data: {}, method: :delete, class: 'btn btn-primary'
+      = link_to 'Cancelar', inventories_path, class: 'btn btn-default'

--- a/app/views/inventories/distributions/confirm_destroy.html.haml
+++ b/app/views/inventories/distributions/confirm_destroy.html.haml
@@ -1,0 +1,10 @@
+.container
+  .card
+    %h3.title Planea
+    %h5.subtitle Inventario de datos
+    .card.padding-top.bg--grey
+      %h5.primary.boldish Eliminar Recurso
+      %p
+        ¿Esta seguro de eliminar el recurso <strong>#{@distribution.title}</strong>, que pertenece al conjunto <strong>#{@distribution.dataset.title}</strong>?
+      = link_to 'Eliminar Recurso', inventories_dataset_distribution_path(@distribution.dataset, @distribution), data: {}, method: :delete, class: 'btn btn-primary'
+      = link_to 'Cancelar', inventories_path, class: 'btn btn-default'

--- a/app/views/inventories/shared/menus/_dataset_actions.html.haml
+++ b/app/views/inventories/shared/menus/_dataset_actions.html.haml
@@ -8,7 +8,7 @@
       = link_to edit_inventories_dataset_path(dataset) do
         Editar
     %li
-      = link_to inventories_dataset_path(dataset), data: {}, method: :delete do
+      = link_to confirm_destroy_inventories_dataset_path(dataset) do
         Eliminar
     %li.divider{ 'role' => 'separator' }
     %li.dropdown-header

--- a/app/views/inventories/shared/menus/_distribution_actions.html.haml
+++ b/app/views/inventories/shared/menus/_distribution_actions.html.haml
@@ -8,5 +8,5 @@
       = link_to edit_inventories_dataset_distribution_path(distribution.dataset, distribution) do
         Editar
     %li
-      = link_to inventories_dataset_distribution_path(distribution.dataset, distribution), data: {}, method: :delete do
+      = link_to confirm_destroy_inventories_dataset_distribution_path(distribution.dataset, distribution) do
         Eliminar

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,10 @@ Adela::Application.routes.draw do
 
   namespace :inventories do
     resources :datasets do
-      resources :distributions
+      get 'confirm_destroy', on: :member
+      resources :distributions do
+        get 'confirm_destroy', on: :member
+      end
     end
   end
 end

--- a/spec/features/user_manages_inventory_datasets_crud_spec.rb
+++ b/spec/features/user_manages_inventory_datasets_crud_spec.rb
@@ -104,6 +104,8 @@ feature User, 'manages inventory datasets crud:' do
       click_on('Eliminar')
     end
 
+    click_on('Eliminar Conjunto')
+
     expect(page).to have_css('.table tbody tr.dataset', count: 2)
     expect(page).to have_css('.table tbody tr.distribution', count: 2)
 
@@ -162,6 +164,8 @@ feature User, 'manages inventory datasets crud:' do
       find('.dropdown').click
       click_on('Eliminar')
     end
+
+    click_on('Eliminar Recurso')
 
     expect(page).to have_css('.table tbody tr.dataset', count: 3)
     expect(page).to have_css('.table tbody tr.distribution', count: 3)


### PR DESCRIPTION
### Changelog
* **Closes #791:** Al eliminar recursos y conjuntos de datos se pide una confirmación al usuario.

### How to test 
1. Sube un inventario de datos.
1. Elimina un recurso.
1. Elimina un conjunto de datos.

<img width="1551" alt="captura de pantalla 2016-03-15 a las 5 54 55 p m" src="https://cloud.githubusercontent.com/assets/764518/13797983/4dcceb82-ead7-11e5-8c56-b3f60cfd0ab4.png">
<img width="1551" alt="captura de pantalla 2016-03-15 a las 5 54 48 p m" src="https://cloud.githubusercontent.com/assets/764518/13797988/509b6460-ead7-11e5-8eb3-360855518a84.png">