### PR TITLE
Updates the catalog distribution text

### DIFF
--- a/app/views/distributions/edit.html.haml
+++ b/app/views/distributions/edit.html.haml
@@ -1,8 +1,16 @@
 .container
   - breadcrumb :distribution, @distribution
   .card
-    %h3.title= "Nombre del recurso: #{@distribution.title}"
-    %p.instructions= "Aquí puedes documentar la información requerida para publicar el recurso en datos.gob.mx"
+    .card.bg--grey.margin-top
+      %h3.title Documenta el Recurso de Datos Abiertos
+      %p
+        Los metadatos ayudan a que los usuarios entiendan las características de la información que se está publicando. La documentación es importante porque afecta la calidad de los datos y el potencial de su uso e impacto.
+      %p
+        Aquí puedes documentar los metadatos según el estándar DCAT para:
+      %p
+        <strong class='highlight'>Nombre del recurso:</strong> #{@distribution.title}
+      %p
+        <strong class='highlight'>Fecha compromiso de publicación:</strong> #{@distribution.dataset.publish_date.strftime('%F')}
     = form_for(@distribution, html: { class: 'form-horizontal' }) do |f|
       .form-group
         .col-xs-12.col-sm-12


### PR DESCRIPTION
### Changelog
* **Closes #861** Se actualiza el copy para documentar una distribución.

### How to Test
1. Publica un conjunto de datos con recursos en el Inventario de Datos.
1. Genera el Plan de Apertura.
1. Documenta un recurso en el Catálogo de Datos.
<img width="1552" alt="captura de pantalla 2016-04-07 a las 4 30 16 p m" src="https://cloud.githubusercontent.com/assets/764518/14367516/16f724a6-fcde-11e5-9fec-bfb7dd4b7d68.png">