### PR TITLE
Updates the catalog datasets copy

### DIFF
--- a/app/views/datasets/edit.html.haml
+++ b/app/views/datasets/edit.html.haml
@@ -1,11 +1,12 @@
 .container
   - breadcrumb :dataset, @dataset
   .card
-    %h3.title= "Nombre del conjunto: #{@dataset.title}"
-    %h5.subtitle= "Fecha de compromiso - #{l(@dataset.publish_date, format: '%d %B %Y')}"
-    %p.instructions
-      Aqu&iacute; puedes documentar la informaci&oacute;n requerida para publicar
-      el conjunto de datos y sus recursos en datos.gob.mx
+    .card.bg--grey.padding-top.margin-top
+      %h3 Documenta el Conjunto de Datos Abiertos
+      %p Los metadatos ayudan a que los usuarios entiendan las características de la información que se está publicando. La documentación es importante porque afecta la calidad de los datos y el potencial de su uso e impacto.
+      %p Aquí puedes documentar los metadatos según el estándar DCAT para:
+      %p <strong class='highlight'>Nombre del conjunto:</strong> #{@dataset.title}
+      %p <strong class='highlight'>Fecha compromiso de publicación:</strong> #{@dataset.publish_date.strftime('%F')}
     .row
       .col-xs-12.col-sm-6
         %p.uppercase.dark Descripci&oacute;n


### PR DESCRIPTION
### Changelog
* **Closes #860:** Agregar copy a la documentación del conjunto de datos en el Catálogo.

### How to Test
1. Agrega un conjunto de datos en el Inventario de Datos.
1. Publica el plan de apertura.
1. Documenta el conjunto de datos en el Catálogo de Datos.

<img width="1552" alt="captura de pantalla 2016-04-07 a las 6 16 05 p m" src="https://cloud.githubusercontent.com/assets/764518/14369750/2070c5c8-fced-11e5-8fe4-a6448a2d9c69.png">