### PR TITLE
Inventory & Catalog Refinement

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -31,6 +31,7 @@
 @import "elements/input";
 @import "elements/button";
 @import "elements/link";
+@import "elements/label";
 @import "elements/table";
 @import "elements/textarea";
 

--- a/app/assets/stylesheets/elements/_button.scss
+++ b/app/assets/stylesheets/elements/_button.scss
@@ -5,7 +5,10 @@
   text-transform: uppercase;
 }
 
-.btn-primary, .btn-primary.disabled {
+.btn-primary,
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-primary.disabled,  {
   @include button($cartoon_green, white);
 }
 

--- a/app/assets/stylesheets/elements/_label.scss
+++ b/app/assets/stylesheets/elements/_label.scss
@@ -1,0 +1,3 @@
+.label.label-default {
+  background-color: #B4B4B4;
+}

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -12,7 +12,7 @@ module DatasetsHelper
   end
 
   def next_dataset(dataset)
-    datasets = current_organization.catalog.datasets.sort_by(&:publish_date)
+    datasets = current_organization.catalog.catalog_datasets.sort_by(&:publish_date)
     index = datasets.index { |ds| ds.id == dataset.id }
     datasets[index + 1]
   end

--- a/app/views/datasets/index.html.haml
+++ b/app/views/datasets/index.html.haml
@@ -7,7 +7,7 @@
     %p
       Aquí puedes documentar los metadatos para los Conjuntos y Recursos de Datos Abiertos
     = form_for @catalog, url: check_organization_catalogs_path(current_organization.catalog), method: :get do |f|
-      %table.table.table-striped
+      %table.table
         %thead.catalog-header
           %tr
             %th.text-center #
@@ -27,8 +27,7 @@
               Acciones
         %tbody
           - @catalog.catalog_datasets.sort_by(&:publish_date).each_with_index do |dataset, index|
-
-            %tr.dataset
+            %tr.dataset.active
               %td.text-center= index + 1
               %td
                 %a.accordion-toggle{'data-toggle' => 'collapse', 'href' => ".dataset_#{dataset.id}_distributions"}

--- a/app/views/datasets/index.html.haml
+++ b/app/views/datasets/index.html.haml
@@ -27,15 +27,19 @@
               Acciones
         %tbody
           - @catalog.catalog_datasets.sort_by(&:publish_date).each_with_index do |dataset, index|
+
             %tr.dataset
               %td.text-center= index + 1
-              %td= dataset.title
+              %td
+                %a.accordion-toggle{'data-toggle' => 'collapse', 'href' => ".dataset_#{dataset.id}_distributions"}
+                  %strong= dataset.title
+                  %span.caret
               %td
               %td= "#{documented_distributions(dataset).count} de #{dataset.distributions.count}"
               %td= l dataset.publish_date.to_date
               %td.action= link_to 'Editar', edit_dataset_path(dataset)
             - dataset.distributions.each do |distribution|
-              %tr.distribution
+              %tr.distribution.accordion-body.collapse{'class' => "dataset_#{distribution.dataset.id}_distributions"}
                 %td
                 %td.nested
                   - if distribution.documented?

--- a/app/views/datasets/index.html.haml
+++ b/app/views/datasets/index.html.haml
@@ -1,13 +1,11 @@
 .container
   - breadcrumb :datasets, @catalog
   .card
-    %h3.title Cat&aacute;logo de datos
-    %h5.subtitle Publica a datos.gob.mx
-    .row
-      .col-xs-12.col-sm-6
-        %p
-          Aqu&iacute; puedes revisar el avance de cada conjunto y editar sus recursos
-          para finalizar el proceso.
+    %h3.title Documenta tus Conjuntos y Recursos de Datos Abiertos
+    %p
+      Los metadatos ayudan a que los usuarios entiendan las características de la información que se está publicando. La documentación es importante porque afecta la calidad de los datos y el potencial de su uso e impacto.
+    %p
+      Aquí puedes documentar los metadatos para los Conjuntos y Recursos de Datos Abiertos
     = form_for @catalog, url: check_organization_catalogs_path(current_organization.catalog), method: :get do |f|
       %table.table.table-striped
         %thead.catalog-header

--- a/app/views/inventories/datasets/edit.html.haml
+++ b/app/views/inventories/datasets/edit.html.haml
@@ -1,8 +1,10 @@
 .container
   .card
-    %h3.title Planea
-    %h5.subtitle Inventario de datos
-    %h5.subtitle Editar Conjunto de Datos
+    %h3.title Conjunto de Datos
+    %p
+      Un <span class='highlight'>Conjunto de datos</span> es un grupo de Recursos de Datos Abiertos que tienen un tema en común. Por ejemplo: El Conjunto de Calidad del Aire agrupa los Recursos de concentraciones de calidad del aire de los 32 estados en un periodo determinado de tiempo.
+    %p
+      Agrega un Conjunto de Datos al Inventario de Datos Abiertos
     = form_for [:inventories, @dataset] do |f|
       .form-group.required
         = f.label :title, class: 'control-label'

--- a/app/views/inventories/datasets/new.html.haml
+++ b/app/views/inventories/datasets/new.html.haml
@@ -1,8 +1,10 @@
 .container
   .card
-    %h3.title Planea
-    %h5.subtitle Inventario de datos
-    %h5.subtitle Conjunto de Datos
+    %h3.title Conjunto de Datos
+    %p
+      Un <span class='highlight'>Conjunto de datos</span> es un grupo de Recursos de Datos Abiertos que tienen un tema en común. Por ejemplo: El Conjunto de Calidad del Aire agrupa los Recursos de concentraciones de calidad del aire de los 32 estados en un periodo determinado de tiempo.
+    %p
+      Agrega un Conjunto de Datos al Inventario de Datos Abiertos
     = nested_form_for [:inventories, Dataset.new] do |f|
       .form-group.required
         = f.label :title, class: 'control-label'

--- a/app/views/inventories/datasets/new.html.haml
+++ b/app/views/inventories/datasets/new.html.haml
@@ -24,8 +24,15 @@
       .form-group.required
         = f.label :publish_date, class: 'control-label'
         = f.text_field :publish_date, class: 'datepicker form-control'
+
+      %h3.title Recursos de Datos
+      %p
+        Un <span class='highlight'>Recurso de datos</span> es un archivo de Datos Abiertos que pertenece a un Conjunto de Datos. Cada Recurso de Datos puede estar disponible en diferentes estructuras (cartográfico, tabular), temporalidades (años, meses), formatos (CSV, API, RSS), agregaciones espaciales (nivel país, estatal, municipal, etc).
+      %p
+        Agrega un Recurso de datos al Conjunto
+
       = f.fields_for :distributions do |distribution_form|
-        %h5.subtitle Recurso
+        %h3.title Recurso de Datos
         .form-group.required
           = distribution_form.label :title, class: 'control-label'
           = distribution_form.text_field :title, required: true, class: 'form-control'
@@ -40,11 +47,12 @@
         .form-group.required
           %label.control-label
             Campos obligatorios
-        .form-group.pull-right
+        .form-group
           = distribution_form.link_to_remove 'Eliminar Recurso', class: 'btn btn-primary'
-          = f.button 'Guardar', type: 'submit', class: 'btn btn-primary'
       .form-group.required
         %label.control-label
           Campos obligatorios
       .form-group
         = f.link_to_add "Agregar Recurso", :distributions, class: 'btn btn-primary'
+        = f.button 'Guardar', type: 'submit', class: 'btn btn-primary pull-right'
+      .clearfix

--- a/app/views/inventories/index.html.haml
+++ b/app/views/inventories/index.html.haml
@@ -11,3 +11,5 @@
       .pull-right
       = render partial: 'inventories/shared/list', locals: { inventory: current_organization.inventory }
       = link_to 'Descargar Inventario Actual', organization_inventory_path(current_organization, format: :csv), { class: 'btn btn-primary' }
+      = link_to 'Ir al Catálogo de Datos', organization_catalogs_path(current_organization), { class: 'btn btn-primary pull-right' }
+      .clearfix

--- a/app/views/inventories/shared/_distribution.html.haml
+++ b/app/views/inventories/shared/_distribution.html.haml
@@ -1,9 +1,10 @@
 %tr.distribution.accordion-body.collapse{'class' => "dataset_#{distribution.dataset.id}_distributions"}
   %td
-  %td.nested= distribution.title
-  %td.center
+  %td.nested
+    = distribution.title
     %span.label.label-default
       = distribution.media_type
+  %td
   %td
   %td.center
     = render partial: 'inventories/shared/menus/distribution_actions', locals: { distribution: distribution }

--- a/app/views/inventories/shared/_list.html.haml
+++ b/app/views/inventories/shared/_list.html.haml
@@ -2,8 +2,7 @@
   %thead
     %tr
       %th #
-      %th
-        Nombre del conjunto
+      %th Nombre del conjunto y sus recursos
       %th.center Acceso
       %th.center Fecha estimada de publicación
       %th.center Acciones

--- a/app/views/inventories/shared/_list.html.haml
+++ b/app/views/inventories/shared/_list.html.haml
@@ -7,4 +7,4 @@
       %th.center Fecha estimada de publicación
       %th.center Acciones
   %tbody
-    = render partial: 'inventories/shared/dataset', collection: current_organization.catalog.editable_datasets
+    = render partial: 'inventories/shared/dataset', collection: current_organization.catalog.editable_datasets.order(public_access: :desc)


### PR DESCRIPTION
### Changelog
* **Closes #880**: Se mueve el formato del recurso abajo del nombre.
* **Closes #877**: Al dar de alta un nuevo conjunto de datos, mostrar el copy de un recurso de datos en la seccion de recursos. 
* **Closes #797**: Se agrega la funcionalidad de acordeon para ampliar o colapsar la lista de recursos en el catálogo.
* **Closes #882**: Se ordenan los conjuntos de datos del inventario de publicos a privados.
* **Closes #881**: Se agrega el botón de ir al catálogo en el inventario de datos.
* **Closes #879**: En el inventario, se cambian la columna de `Nombre del conjunto` por `Nombre del conjunto y sus recursos`.
* **Closes #884**: Se acutaliza el copy del home del inventario.

### How to test
1. En el inventario, validar que la etiqueta con el formato del recurso salga al final de la descripción del recurso.
1. Al agregar un nuevo conjunto de datos, verificar que se muestre el copy de los recursos.
1. En el catálogo de datos, verificar la funcionalidad de acordeon en los conjuntos y recursos.
1. En el inventario de datos, verificar que los conjuntos de datos esten ordenados de publicos a privados.
1. Verificar que se muestre el boton de ir al catálogo en el inventario de datos.
1. Verificar en el inventario, que salga la columna `Nombre del conjunto y sus recursos`.
1. Verificar en el home del inventario, que se muestre el nuevo copy.


