### PR TITLE
dct:contactPoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'tzinfo-data'
 gem 'momentjs-rails'
 gem 'active_link_to'
 gem 'as_csv', '~> 2.0'
+gem 'vcardigan'
 
 group :development, :test do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,6 +357,7 @@ GEM
     validate_url (1.0.2)
       activemodel (>= 3.0.0)
       addressable
+    vcardigan (0.0.9)
     warden (1.2.4)
       rack (>= 1.0)
     websocket (1.2.2)
@@ -437,6 +438,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   validate_url
+  vcardigan
   will_paginate (~> 3.0)
 
 BUNDLED WITH

--- a/app/controllers/api/v1/datasets_controller.rb
+++ b/app/controllers/api/v1/datasets_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::DatasetsController < ApplicationController
+  def contact_point
+    dataset = Dataset.find(params[:id])
+    send_data vcard(dataset).to_s
+  end
+
+  private
+
+  def vcard(dataset)
+    vcard = VCardigan.create
+    vcard.fullname dataset.contact_position
+    vcard.email dataset.mbox, type: ['work', 'internet'], preferred: 1
+    vcard
+  end
+end

--- a/app/models/inventory_dataset_generator.rb
+++ b/app/models/inventory_dataset_generator.rb
@@ -64,7 +64,6 @@ class InventoryDatasetGenerator
       dataset.keyword = 'inventario'
       dataset.modified = Time.current.iso8601
       dataset.contact_position = ENV_CONTACT_POSITION_NAME
-      dataset.contact_point = organization_administrator.try(:name)
       dataset.mbox = organization_administrator.try(:email)
       dataset.temporal = Time.current.year
       dataset.landing_page = @organization.landing_page

--- a/app/serializers/dataset_serializer.rb
+++ b/app/serializers/dataset_serializer.rb
@@ -17,7 +17,7 @@ class DatasetSerializer < ActiveModel::Serializer
   end
 
   def contactPoint
-    object.contact_point
+    "http://adela.datos.gob.mx/api/v1/datasets/#{object.id}/contact_point.vcf"
   end
 
   def distributions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,10 @@ Adela::Application.routes.draw do
       get '/organizations' => 'organizations#organizations'
       get '/gov_types' => 'organizations#gov_types'
 
+      resources :datasets, only: [] do
+        get 'contact_point', on: :member
+      end
+
       resources :organizations, only: [:show] do
         collection do
           get 'catalogs'

--- a/db/migrate/20160421230940_remove_contact_point_from_datasets.rb
+++ b/db/migrate/20160421230940_remove_contact_point_from_datasets.rb
@@ -1,0 +1,5 @@
+class RemoveContactPointFromDatasets < ActiveRecord::Migration
+  def change
+    remove_column :datasets, :contact_point, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160419214732) do
+ActiveRecord::Schema.define(version: 20160421230940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,7 +64,6 @@ ActiveRecord::Schema.define(version: 20160419214732) do
     t.text     "description"
     t.text     "keyword"
     t.datetime "modified"
-    t.string   "contact_point"
     t.string   "mbox"
     t.string   "temporal"
     t.string   "spatial"

--- a/spec/controllers/api/v1/datasets_controller_spec.rb
+++ b/spec/controllers/api/v1/datasets_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Api::V1::DatasetsController do
+  describe 'GET #contact_point' do
+    before(:each) do
+      @dataset = create(:dataset)
+    end
+
+    it 'downloads the dataset contact point vcard' do
+      get :contact_point, id: @dataset.id, locale: :es
+      expect(response.body).to eq(
+        "BEGIN:VCARD\nVERSION:4.0\nFN:#{@dataset.contact_position}\nEMAIL;TYPE=[\"work\", \"internet\"];PREF=1:#{@dataset.mbox}\nEND:VCARD\n"
+      )
+    end
+  end
+end

--- a/spec/factories/datasets.rb
+++ b/spec/factories/datasets.rb
@@ -5,7 +5,6 @@ FactoryGirl.define do
     keyword { Faker::Lorem.words.join(',') }
     modified { Faker::Time.forward }
     contact_position { Faker::Company.profession }
-    contact_point { Faker::Name.name }
     mbox { Faker::Internet.email }
     temporal { "#{Faker::Date.backward.iso8601}/#{Faker::Date.forward.iso8601}" }
     spatial { Faker::Address.state }


### PR DESCRIPTION
### Changelog
1. Se expone una API que genera una vcard para el campo `contact_point` de un dataset.
1. Se expone en la API del catalogo la URL para consumir la vcard de un dataset.

### How to Test
1. Agregar un conjunto de datos y documentarlo en el Catálogo de Datos.
1. Publicar el catálogo de datos.
1. Consumir la API del catálogo  en `/:slug-organizacion:/catalogo.json`.
1. Verificar el campo `contact_point` del dataset.
1. Consumir la API de la vcard del dataset en `/api/v1/datasets/:id-dataset:/contact_point.vcf`.

Closes #892