### PR TITLE
dct:temporal

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -28,6 +28,7 @@ class DatasetsController < ApplicationController
       :contact_position,
       :mbox,
       :landing_page,
+      :temporal,
       :keyword,
       dataset_sector_attributes: [:sector_id]
     )

--- a/app/serializers/dataset_serializer.rb
+++ b/app/serializers/dataset_serializer.rb
@@ -2,7 +2,7 @@ include ActiveModel::Serialization
 
 class DatasetSerializer < ActiveModel::Serializer
   has_many :distributions, root: :distribution
-  attributes :identifier, :title, :description, :modified, :contactPoint, :spatial
+  attributes :identifier, :title, :description, :modified, :contactPoint, :spatial, :temporal
 
   def attributes
     data = super

--- a/app/views/datasets/edit.html.haml
+++ b/app/views/datasets/edit.html.haml
@@ -48,6 +48,12 @@
 
           .form-group
             .col-xs-12.col-sm-12
+              = f.label :temporal
+            .col-xs-12.col-sm-12
+              = f.text_field :temporal, class: 'form-control auto_submit_item'
+
+          .form-group
+            .col-xs-12.col-sm-12
               = f.label :landing_page, 'URL para consultar diccionario de datos *'
             .col-xs-12.col-sm-12
               = f.url_field :landing_page, class: 'form-control auto_submit_item'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -123,6 +123,7 @@ es:
         public_access: '¿Tiene datos privados?'
         accrual_periodicity: 'Frecuencia con la que actualizan'
         publish_date: 'Fecha de publicación'
+        temporal: 'Cobertura temporal'
       distribution:
         title: 'Nombre del Recurso'
         description: 'Descripción del Recurso'

--- a/spec/features/catalog/dataset_metadata_spec.rb
+++ b/spec/features/catalog/dataset_metadata_spec.rb
@@ -22,6 +22,7 @@ feature 'Catalog dataset metadata' do
 
     expect(page).to have_field('dataset_contact_position', with: dataset_attributes[:contact_position])
     expect(page).to have_field('dataset_mbox', with: dataset_attributes[:mbox])
+    expect(page).to have_field('dataset_temporal', with: dataset_attributes[:temporal])
     expect(page).to have_field('dataset_landing_page', with: dataset_attributes[:landing_page])
     expect(page).to have_field('dataset_keyword', with: dataset_attributes[:keyword])
   end
@@ -29,6 +30,7 @@ feature 'Catalog dataset metadata' do
   def fill_catalog_dataset_metadata(dataset_attributes)
     fill_in('dataset_contact_position', with: dataset_attributes[:contact_position])
     fill_in('dataset_mbox', with: dataset_attributes[:mbox])
+    fill_in('dataset_temporal', with: dataset_attributes[:temporal])
     fill_in('dataset_landing_page', with: dataset_attributes[:landing_page])
     fill_in('dataset_keyword', with: dataset_attributes[:keyword])
     page.find('form').click # trigger the autosubmit by clicking anywhere

--- a/spec/requests/data_catalog_management_spec.rb
+++ b/spec/requests/data_catalog_management_spec.rb
@@ -41,7 +41,7 @@ feature 'data catalog management' do
     distribution.update_column(:state, 'published')
 
     dcat_keys = %w(title description homepage issued modified language license dataset)
-    dcat_dataset_keys = %w(identifier title description keyword modified contactPoint spatial landingPage language publisher distribution)
+    dcat_dataset_keys = %w(identifier title description keyword modified contactPoint spatial landingPage language publisher distribution temporal)
     dcat_distribution_keys = %w(title description license downloadURL mediaType byteSize temporal spatial)
 
     get "/#{organization.slug}/catalogo.json"


### PR DESCRIPTION
### Changelog
* Se agrega la opcion de editar el campo `dct:temporal` en el catálogo de datos.

### How to Test
1. En el inventario de datos, agregar un conjunto de datos, con al menos un recurso.
1. En el catálogo de datos, documentar el conjunto de datos agregado.
1. Publicar el catálogo de datos.
1. Consultar la API del catálogo de datos `/:slug-organizacion:/catalogo.json` y verificar el campo temporal`.

Closes #893