### PR TITLE
dct:spatial

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -29,6 +29,7 @@ class DatasetsController < ApplicationController
       :mbox,
       :landing_page,
       :temporal,
+      :spatial,
       :keyword,
       dataset_sector_attributes: [:sector_id]
     )

--- a/app/views/datasets/edit.html.haml
+++ b/app/views/datasets/edit.html.haml
@@ -48,6 +48,12 @@
 
           .form-group
             .col-xs-12.col-sm-12
+              = f.label :spatial
+            .col-xs-12.col-sm-12
+              = f.text_field :spatial, class: 'form-control auto_submit_item'
+
+          .form-group
+            .col-xs-12.col-sm-12
               = f.label :temporal
             .col-xs-12.col-sm-12
               = f.text_field :temporal, class: 'form-control auto_submit_item'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -124,6 +124,7 @@ es:
         accrual_periodicity: 'Frecuencia con la que actualizan'
         publish_date: 'Fecha de publicación'
         temporal: 'Cobertura temporal'
+        spatial: 'Espacio geográfico'
       distribution:
         title: 'Nombre del Recurso'
         description: 'Descripción del Recurso'

--- a/spec/factories/datasets.rb
+++ b/spec/factories/datasets.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     contact_position { Faker::Company.profession }
     mbox { Faker::Internet.email }
     temporal { "#{Faker::Date.backward.iso8601}/#{Faker::Date.forward.iso8601}" }
-    spatial { Faker::Address.state }
+    spatial { "#{Faker::Address.latitude}/#{Faker::Address.longitude}" }
     landing_page { Faker::Internet.url }
     accrual_periodicity 'R/P1Y'
     publish_date { Faker::Time.forward }

--- a/spec/features/catalog/dataset_metadata_spec.rb
+++ b/spec/features/catalog/dataset_metadata_spec.rb
@@ -22,6 +22,7 @@ feature 'Catalog dataset metadata' do
 
     expect(page).to have_field('dataset_contact_position', with: dataset_attributes[:contact_position])
     expect(page).to have_field('dataset_mbox', with: dataset_attributes[:mbox])
+    expect(page).to have_field('dataset_spatial', with: dataset_attributes[:spatial])
     expect(page).to have_field('dataset_temporal', with: dataset_attributes[:temporal])
     expect(page).to have_field('dataset_landing_page', with: dataset_attributes[:landing_page])
     expect(page).to have_field('dataset_keyword', with: dataset_attributes[:keyword])
@@ -30,6 +31,7 @@ feature 'Catalog dataset metadata' do
   def fill_catalog_dataset_metadata(dataset_attributes)
     fill_in('dataset_contact_position', with: dataset_attributes[:contact_position])
     fill_in('dataset_mbox', with: dataset_attributes[:mbox])
+    fill_in('dataset_spatial', with: dataset_attributes[:spatial])
     fill_in('dataset_temporal', with: dataset_attributes[:temporal])
     fill_in('dataset_landing_page', with: dataset_attributes[:landing_page])
     fill_in('dataset_keyword', with: dataset_attributes[:keyword])


### PR DESCRIPTION
### Changelog
* Se agrega la opcion de editar el campo `dct:spatial` en el catálogo de datos.

### How to Test
1. En el inventario de datos, agregar un conjunto de datos, con al menos un recurso.
1. En el catálogo de datos, documentar el conjunto de datos agregado.
1. Publicar el catálogo de datos.
1. Consultar la API del catálogo de datos `/:slug-organizacion:/catalogo.json` y verificar el campo `spatial`.

Fixes #894 