### PR TITLE
dct:issued

### DIFF
--- a/app/controllers/catalogs_controller.rb
+++ b/app/controllers/catalogs_controller.rb
@@ -44,6 +44,8 @@ class CatalogsController < ApplicationController
     catalog_params['distribution_ids'].each do |id|
       distribution = Distribution.find(id)
       distribution.update_column(:state, 'published')
+      distribution.dataset.update_column(:issued, Time.current) if distribution.dataset.issued.blank?
+      distribution.update_column(:issued, Time.current) if distribution.issued.blank?
     end
   end
 

--- a/app/serializers/dataset_serializer.rb
+++ b/app/serializers/dataset_serializer.rb
@@ -2,7 +2,7 @@ include ActiveModel::Serialization
 
 class DatasetSerializer < ActiveModel::Serializer
   has_many :distributions, root: :distribution
-  attributes :identifier, :title, :description, :modified, :contactPoint, :spatial, :temporal
+  attributes :identifier, :title, :description, :modified, :contactPoint, :spatial, :issued, :temporal
 
   def attributes
     data = super

--- a/app/serializers/distribution_serializer.rb
+++ b/app/serializers/distribution_serializer.rb
@@ -1,6 +1,6 @@
 class DistributionSerializer < ActiveModel::Serializer
   attributes :title, :description, :downloadURL, :mediaType, :byteSize,
-             :temporal, :spatial, :license
+             :temporal, :spatial, :license, :issued
 
   def license
     'http://datos.gob.mx/libreusomx/'

--- a/db/migrate/20160422164828_add_issued_to_datasets.rb
+++ b/db/migrate/20160422164828_add_issued_to_datasets.rb
@@ -1,0 +1,5 @@
+class AddIssuedToDatasets < ActiveRecord::Migration
+  def change
+    add_column :datasets, :issued, :datetime
+  end
+end

--- a/db/migrate/20160424200702_add_issued_to_distributions.rb
+++ b/db/migrate/20160424200702_add_issued_to_distributions.rb
@@ -1,0 +1,5 @@
+class AddIssuedToDistributions < ActiveRecord::Migration
+  def change
+    add_column :distributions, :issued, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160422164828) do
+ActiveRecord::Schema.define(version: 20160424200702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 20160422164828) do
     t.datetime "updated_at"
     t.datetime "modified"
     t.string   "state"
+    t.datetime "issued"
   end
 
   add_index "distributions", ["dataset_id"], name: "index_distributions_on_dataset_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160421230940) do
+ActiveRecord::Schema.define(version: 20160422164828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 20160421230940) do
     t.string   "contact_position"
     t.boolean  "public_access",       default: true
     t.boolean  "editable",            default: true
+    t.datetime "issued"
   end
 
   add_index "datasets", ["catalog_id"], name: "index_datasets_on_catalog_id", using: :btree

--- a/spec/factories/datasets.rb
+++ b/spec/factories/datasets.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     spatial { "#{Faker::Address.latitude}/#{Faker::Address.longitude}" }
     landing_page { Faker::Internet.url }
     accrual_periodicity 'R/P1Y'
+    issued { Faker::Time.forward }
     publish_date { Faker::Time.forward }
     public_access true
     editable true

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     temporal { "#{Faker::Date.backward.iso8601}/#{Faker::Date.forward.iso8601}" }
     modified { Faker::Time.forward }
     spatial { Faker::Address.state }
+    issued {  Faker::Time.forward }
     dataset
 
     factory :catalog_distribution do

--- a/spec/requests/data_catalog_management_spec.rb
+++ b/spec/requests/data_catalog_management_spec.rb
@@ -41,8 +41,8 @@ feature 'data catalog management' do
     distribution.update_column(:state, 'published')
 
     dcat_keys = %w(title description homepage issued modified language license dataset)
-    dcat_dataset_keys = %w(identifier title description keyword modified contactPoint spatial landingPage language publisher distribution temporal)
-    dcat_distribution_keys = %w(title description license downloadURL mediaType byteSize temporal spatial)
+    dcat_dataset_keys = %w(identifier title description keyword modified contactPoint spatial landingPage language publisher distribution temporal issued)
+    dcat_distribution_keys = %w(title description license downloadURL mediaType byteSize temporal spatial issued)
 
     get "/#{organization.slug}/catalogo.json"
     json_response = JSON.parse(response.body)


### PR DESCRIPTION
### Changelog
1. Se agrega el campo `dct:issued` al modelo de `Dataset` y `Distribution`.
1. Al momento de publicar un conjunto de datos y sus distribuciones, se llena el campo `dct:issued`.
1. Se expone el campo `dct:issued` en la API del Catálogo de Datos.

### How to Test
1. Publicar el catálogo de datos de una organización.
1. Verificar en la API que se muestre el campo `dct:issued` en los conjuntos de datos y distribuciones.

Closes #891 
Closes #895