### PR TITLE
dcat:byteSize

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -15,6 +15,6 @@ class DistributionsController < ApplicationController
   private
 
   def distribution_params
-    params.require(:distribution).permit(:download_url, :modified, :temporal)
+    params.require(:distribution).permit(:download_url, :modified, :temporal, :byte_size)
   end
 end

--- a/app/views/datasets/edit.html.haml
+++ b/app/views/datasets/edit.html.haml
@@ -81,7 +81,7 @@
       %p.instructions
         Continúa con la documentación de los recursos de este conjunto de datos
 
-    %table.table.table-striped.table-condensed
+    %table.table.table-condensed
       %thead
         %tr
           %th
@@ -95,7 +95,7 @@
             %i.fa.fa-caret-down
       %tbody
         - @dataset.distributions.each do |distribution|
-          %tr
+          %tr.distribution
             %td= distribution.title
             %td.status= state_description(distribution)
             %td.action= link_to edit_link_to_text(distribution), edit_distribution_path(distribution)

--- a/app/views/distributions/edit.html.haml
+++ b/app/views/distributions/edit.html.haml
@@ -38,7 +38,7 @@
           = f.label(:modified, 'Fecha de última modificación de datos *')
         .col-xs-12.col-sm-3
           .input-group
-            = f.text_field(:modified, class: 'input-icon datepicker', required: true)
+            = f.text_field(:modified, value: f.object.modified&.strftime('%F'), class: 'input-icon datepicker', required: true)
             %span.input-group-addon
               %i.fa.fa-calendar
 

--- a/app/views/distributions/edit.html.haml
+++ b/app/views/distributions/edit.html.haml
@@ -42,6 +42,12 @@
             %span.input-group-addon
               %i.fa.fa-calendar
 
+      .form-group
+        .col-xs-12.col-sm-12
+          = f.label(:byte_size, 'Tamaño en Bytes')
+        .col-xs-12.col-sm-3
+          = f.text_field(:byte_size,  class: 'form-control')
+
       = f.button 'Guardar avance', type: 'submit', class: 'btn btn-primary'
       = link_to 'Cancelar', edit_dataset_path(@distribution.dataset), class: 'btn btn-primary'
 

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
       download_url nil
       temporal nil
       modified nil
+      byte_size nil
     end
 
     trait :broke do

--- a/spec/features/catalog/distribution_metadata_spec.rb
+++ b/spec/features/catalog/distribution_metadata_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+feature 'Catalog distribution metadata' do
+  before do
+    @user = FactoryGirl.create(:user)
+    given_logged_in_as(@user)
+  end
+
+  scenario 'fills the distribution metadata', js: true do
+    given_organization_with_catalog
+    within('.navbar') { click_on('Catálogo de Datos') }
+    close_joyride
+
+    within set_row do
+      click_on('Editar')
+    end
+
+    within resource_row do
+      expect(page).to have_text('Falta información')
+      click_on('Completar')
+    end
+
+    distribution_attributes = attributes_for(:distribution)
+    fill_catalog_distribution_metadata(distribution_attributes)
+
+    within resource_row do
+      expect(page).to have_text('Listo para publicar')
+      click_on('Actualizar')
+    end
+
+    expect(page).to have_field('distribution_download_url', with: distribution_attributes[:download_url])
+    expect(page).to have_field('init-date', with: distribution_attributes[:temporal].split('/')[0])
+    expect(page).to have_field('term-date', with: distribution_attributes[:temporal].split('/')[1])
+    expect(page).to have_field('distribution_modified', with: distribution_attributes[:modified].strftime('%F'))
+    expect(page).to have_field('distribution_byte_size', with: distribution_attributes[:byte_size])
+  end
+
+  def fill_catalog_distribution_metadata(distribution_attributes)
+    fill_in('distribution_download_url', with: distribution_attributes[:download_url])
+    fill_in('init-date', with: distribution_attributes[:temporal].split('/')[0])
+    fill_in('term-date', with: distribution_attributes[:temporal].split('/')[1])
+    fill_in('distribution_modified', with: distribution_attributes[:modified].strftime('%F'))
+    fill_in('distribution_byte_size', with: distribution_attributes[:byte_size])
+    page.find('form').click # close the date picker by clicking anywhere
+    click_on('Guardar avance')
+  end
+end

--- a/spec/support/features/helper_methods.rb
+++ b/spec/support/features/helper_methods.rb
@@ -51,6 +51,10 @@ module Features
       all('table tbody tr.distribution')
     end
 
+    def resource_row
+      resource_rows.first
+    end
+
     def close_joyride
       page.find('.joyride-close-tip').click
     end


### PR DESCRIPTION
### Changelog
1. Se agrega el campo `dcat:byteSize` al formulario de un recurso en el catálogo de datos.
1. En el formulario de un recurso, en el catálogo de datos, se muestra el campo modified en formato iso8601.

### How to Test
1. En el Inventario de Datos, agregar un conjunto de datos con recursos.
1. En el Catálogo de Datos, documentar el conjunto de datos y sus recursos.
1. Publicar el Catálogo de Datos.
1. Consumir la API del catalogo y verificar el campo `dcat:byteSize` en las distribuciones.

Closes #901 