### PR TITLE
Distribution publish date #896

### DIFF
--- a/app/controllers/inventories/datasets_controller.rb
+++ b/app/controllers/inventories/datasets_controller.rb
@@ -33,7 +33,7 @@ class Inventories::DatasetsController < ApplicationController
       :public_access,
       :accrual_periodicity,
       :publish_date,
-      distributions_attributes: [:id, :title, :description, :media_type, :_destroy]
+      distributions_attributes: [:id, :title, :description, :publish_date, :media_type, :_destroy]
     )
   end
 end

--- a/app/controllers/inventories/distributions_controller.rb
+++ b/app/controllers/inventories/distributions_controller.rb
@@ -24,6 +24,6 @@ class Inventories::DistributionsController < ApplicationController
   end
 
   def distribution_params
-    params.require(:distribution).permit(:title, :description, :media_type)
+    params.require(:distribution).permit(:title, :description, :publish_date, :media_type)
   end
 end

--- a/app/models/inventory_dataset_generator.rb
+++ b/app/models/inventory_dataset_generator.rb
@@ -94,6 +94,7 @@ class InventoryDatasetGenerator
       distribution.description = "Inventario Institucional de Datos de #{@organization.title}"
       distribution.download_url = "http://adela.datos.gob.mx#{organization_inventory_path(@organization, format: :csv)}"
       distribution.media_type = 'csv'
+      distribution.publish_date = DateTime.new(2015, 8, 28)
       distribution.temporal = build_temporal(dataset.modified)
       distribution.modified = dataset.modified
     end

--- a/app/views/datasets/index.html.haml
+++ b/app/views/datasets/index.html.haml
@@ -46,7 +46,7 @@
                   = distribution.title
                 %td.status= state_description(distribution)
                 %th
-                %th
+                %th= distribution.publish_date&.strftime('%F')
                 %td.action= link_to edit_link_to_text(distribution), edit_distribution_path(distribution)
 
       = f.button 'Publicar', type: 'submit', id: 'publish', class: can_publish?(@catalog) ? 'btn btn-primary' : 'btn btn-primary disabled'

--- a/app/views/inventories/datasets/new.html.haml
+++ b/app/views/inventories/datasets/new.html.haml
@@ -40,6 +40,9 @@
           = distribution_form.label :description, class: 'control-label'
           = distribution_form.text_area :description, required: true, class: 'autosize form-control'
         .form-group.required
+          = distribution_form.label :publish_date, class: 'control-label'
+          = distribution_form.text_field :publish_date, value: distribution_form.object.publish_date&.strftime('%F'), required: true, class: 'datepicker auto_submit_item form-control'
+        .form-group.required
           = distribution_form.label :media_type, class: 'control-label'
           = select_tag :media_type_select, options_for_media_type, class: 'form-control media_type_select'
         .form-group

--- a/app/views/inventories/distributions/edit.html.haml
+++ b/app/views/inventories/distributions/edit.html.haml
@@ -13,6 +13,9 @@
         = f.label :description, class: 'control-label'
         = f.text_area :description, required: true, class: 'autosize form-control'
       .form-group.required
+        = f.label :publish_date, class: 'control-label'
+        = f.text_field :publish_date, value: f.object.publish_date&.strftime('%F'), required: true, class: 'datepicker auto_submit_item form-control'
+      .form-group.required
         = f.label :media_type, class: 'control-label'
         = select_tag :media_type_select, options_for_media_type, class: 'form-control'
       .form-group

--- a/app/views/inventories/shared/_distribution.html.haml
+++ b/app/views/inventories/shared/_distribution.html.haml
@@ -5,6 +5,7 @@
     %span.label.label-default
       = distribution.media_type
   %td
-  %td
+  %td.center
+    = distribution.publish_date&.strftime('%F')
   %td.center
     = render partial: 'inventories/shared/menus/distribution_actions', locals: { distribution: distribution }

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -128,6 +128,7 @@ es:
       distribution:
         title: 'Nombre del Recurso'
         description: 'Descripción del Recurso'
+        publish_date: 'Fecha de publicación'
         media_type: 'Formato del recurso'
       organization:
         title: "Nombre"

--- a/db/migrate/20160425131934_add_publish_date_to_distributions.rb
+++ b/db/migrate/20160425131934_add_publish_date_to_distributions.rb
@@ -1,0 +1,5 @@
+class AddPublishDateToDistributions < ActiveRecord::Migration
+  def change
+    add_column :distributions, :publish_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160424200702) do
+ActiveRecord::Schema.define(version: 20160425131934) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,6 +104,7 @@ ActiveRecord::Schema.define(version: 20160424200702) do
     t.datetime "modified"
     t.string   "state"
     t.datetime "issued"
+    t.datetime "publish_date"
   end
 
   add_index "distributions", ["dataset_id"], name: "index_distributions_on_dataset_id", using: :btree

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
     modified { Faker::Time.forward }
     spatial { Faker::Address.state }
     issued {  Faker::Time.forward }
+    publish_date { Time.current }
     dataset
 
     factory :catalog_distribution do

--- a/spec/features/user_manages_inventory_datasets_crud_spec.rb
+++ b/spec/features/user_manages_inventory_datasets_crud_spec.rb
@@ -212,6 +212,7 @@ feature User, 'manages inventory datasets crud:' do
     within('.fields') do
       find("input[id^='dataset_distributions_attributes_'][id$='title']").set(distribution_attributes[:title])
       find("textarea[id^='dataset_distributions_attributes_'][id$='description']").set(distribution_attributes[:description])
+      find("input[id^='dataset_distributions_attributes_'][id$='publish_date']").set(distribution_attributes[:publish_date])
       select('json', from: 'media_type_select')
     end
   end


### PR DESCRIPTION
### Changelog
1. Se agrega el campo `publish_date` al modelo distributions.

### How to Test
1. En el Inventario de Datos, agregar un conjunto de datos con al menos un recurso.
1. Verificar que se muestre el campo de fecha de publicación en el formulario del recurso.
1. En el Catálogo de Datos, documentar el conjunto de datos y publicar el catálogo.

Closes #896 