### PR TITLE
Adds the accrualPeriodicity to the catalog API

### DIFF
--- a/app/serializers/dataset_serializer.rb
+++ b/app/serializers/dataset_serializer.rb
@@ -13,6 +13,7 @@ class DatasetSerializer < ActiveModel::Serializer
     }
     data[:keyword] = object.keywords.split(',').map(&:squish)
     data[:landingPage] = object.landing_page
+    data[:accrualPeriodicity] = object.accrual_periodicity
     data
   end
 

--- a/spec/requests/data_catalog_management_spec.rb
+++ b/spec/requests/data_catalog_management_spec.rb
@@ -41,7 +41,7 @@ feature 'data catalog management' do
     distribution.update_column(:state, 'published')
 
     dcat_keys = %w(title description homepage issued modified language license dataset)
-    dcat_dataset_keys = %w(identifier title description keyword modified contactPoint spatial landingPage language publisher distribution)
+    dcat_dataset_keys = %w(identifier title description keyword modified contactPoint spatial landingPage language publisher distribution accrualPeriodicity)
     dcat_distribution_keys = %w(title description license downloadURL mediaType byteSize temporal spatial)
 
     get "/#{organization.slug}/catalogo.json"


### PR DESCRIPTION
### Changelog
1. Se expone el campo `dct:accrualPeriodicity` en la API del catálogo.

### How to test
1. Consulta el catálogo de una organización en `/:slug-organización:/catalogo.json`.