### PR TITLE
WIP - Tooltips

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -23,6 +23,7 @@
 //= require jquery.cookie
 //= require components/datepicker
 //= require components/table-checkbox
+//= require components/tooltip
 //= require components/agreement
 //= require webcomponentsjs/webcomponents-lite
 //= require_self

--- a/app/assets/javascripts/components/tooltip.js
+++ b/app/assets/javascripts/components/tooltip.js
@@ -1,0 +1,3 @@
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})

--- a/app/assets/javascripts/datasets.js
+++ b/app/assets/javascripts/datasets.js
@@ -42,4 +42,5 @@ $(document).on('nested:fieldAdded', function(event){
 
     $('.media_type_select').on('change', updateMediaType);
     $('.datepicker').datepicker();
+    $('[data-toggle="tooltip"]').tooltip();
 })

--- a/app/views/datasets/edit.html.haml
+++ b/app/views/datasets/edit.html.haml
@@ -7,47 +7,47 @@
     = form_for(@dataset, remote: true) do |f|
       .form-group.required
         = f.label :title, class: 'control-label'
-        = f.text_field :title, required: true, class: 'form-control auto_submit_item'
+        = f.text_field :title, required: true, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.title')}"
       .form-group.required
         = f.label :description, class: 'control-label'
-        = f.text_area :description, required: true, class: 'form-control auto_submit_item autosize'
+        = f.text_area :description, required: true, class: 'form-control auto_submit_item autosize', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.description')}"
       .row
         .col-xs-6
           .form-group.required
             = f.label :accrual_periodicity, class: 'control-label'
-            = f.select :accrual_periodicity, iso8601_repeating_interval_options_for_select(f.object.accrual_periodicity), {}, required: true, class: 'form-control auto_submit_item'
+            = f.select :accrual_periodicity, iso8601_repeating_interval_options_for_select(f.object.accrual_periodicity), {}, required: true, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.accrual_periodicity')}"
         .col-xs-6
           .form-group.required
             = f.label :publish_date, class: 'control-label'
-            = f.text_field :publish_date, value: f.object.publish_date.strftime('%F'), class: 'datepicker auto_submit_item form-control'
+            = f.text_field :publish_date, value: f.object.publish_date.strftime('%F'), class: 'datepicker auto_submit_item form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.publish_date')}"
       .row
         .col-xs-6
           .form-group.required
             = f.label :contact_position, 'Cargo del responsable'
-            = f.text_field :contact_position, class: 'form-control auto_submit_item'
+            = f.text_field :contact_position, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.contact_position')}"
         .col-xs-6
           .form-group.required
             = f.label :mbox, 'Correo del responsable'
-            = f.email_field :mbox, class: 'form-control auto_submit_item'
+            = f.email_field :mbox, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.email_field')}"
       .row
         .col-xs-6
           .form-group.required
             = f.label :spatial
-            = f.text_field :spatial, class: 'form-control auto_submit_item'
+            = f.text_field :spatial, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.spatial')}"
         .col-xs-6
           .form-group.required
             = f.label :temporal
-            = f.text_field :temporal, class: 'form-control auto_submit_item'
+            = f.text_field :temporal, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.temporal')}"
       .form-group.required
         = f.label :landing_page, 'URL para consultar diccionario de datos'
-        = f.url_field :landing_page, class: 'form-control auto_submit_item'
+        = f.url_field :landing_page, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.landing_page')}"
       .form-group.required
         = f.label :dataset_sectors, 'Sector'
         = f.fields_for :dataset_sector do |sector_form|
-          = sector_form.select :sector_id, options_for_sectors_select, { include_blank: true }, { class: 'form-control auto_submit_item' }
+          = sector_form.select :sector_id, options_for_sectors_select, { include_blank: true }, { class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.sector')}" }
       .form-group.required
         = f.label :keyword, 'Palabras clave (separadas por coma)'
-        = f.text_area :keyword, class: 'form-control auto_submit_item'
+        = f.text_area :keyword, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.keyword')}"
   .col-md-3
     .jumbotron.center
       %p

--- a/app/views/distributions/edit.html.haml
+++ b/app/views/distributions/edit.html.haml
@@ -6,27 +6,27 @@
   .col-md-9
     = form_for(@distribution) do |f|
       .form-group.required
-        = f.label(:download_url, 'URL para descargar')
-        = f.url_field(:download_url, class: 'form-control', required: true)
+        = f.label :download_url, 'URL para descargar'
+        = f.url_field :download_url, class: 'form-control', required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.download_url')}"
       .row
         = f.hidden_field(:temporal)
         .col-xs-6
           .form-group.required
             = f.label :temporal, 'Inicio del período de tiempo cubierto', class: 'control-label'
-            %input#init-date.dcat-temporal.datepicker.form-control{ type: "text", placeholder: "Inicio", required: true }
+            %input#init-date.dcat-temporal.datepicker.form-control{ type: "text", placeholder: "Inicio", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.temporal.init')}" }
         .col-xs-6
           .form-group.required
             = f.label :temporal, 'Fin del período de tiempo cubierto', class: 'control-label'
-            %input#term-date.dcat-temporal.datepicker.form-control{ type: "text", placeholder: "Fin", required: true }
+            %input#term-date.dcat-temporal.datepicker.form-control{ type: "text", placeholder: "Fin", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.temporal.term')}" }
       .row
         .col-xs-6
           .form-group.required
             = f.label :modified, 'Fecha de última modificación de datos',  class: 'control-label'
-            = f.text_field :modified, value: f.object.modified&.strftime('%F'), class: 'form-control input-icon datepicker', required: true
+            = f.text_field :modified, value: f.object.modified&.strftime('%F'), class: 'form-control input-icon datepicker', required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.modified')}"
         .col-xs-6
           .form-group.required
             = f.label :byte_size, 'Tamaño en Bytes'
-            = f.text_field :byte_size,  class: 'form-control'
+            = f.text_field :byte_size,  class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.byte_size')}"
 
       = f.button 'Guardar avance', type: 'submit', class: 'btn btn-primary btn-lg pull-right'
       = link_to 'Cancelar', edit_dataset_path(@distribution.dataset), class: 'btn btn-alt btn-lg'

--- a/app/views/inventories/datasets/edit.html.haml
+++ b/app/views/inventories/datasets/edit.html.haml
@@ -7,26 +7,26 @@
     .col-md-9
       .form-group.required
         = f.label :title, class: 'control-label'
-        = f.text_field :title, required: true, class: 'form-control'
+        = f.text_field :title, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.title')}"
       .form-group.required
         = f.label :description, class: 'control-label'
-        = f.text_area :description, required: true, class: 'autosize form-control'
+        = f.text_area :description, required: true, class: 'autosize form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.description')}"
       .form-group.required
         = f.label :contact_position, class: 'control-label'
-        = f.text_field :contact_position, required: true, class: 'form-control'
+        = f.text_field :contact_position, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.contact_position')}"
       .row
         .col-xs-4
           .form-group.required
             = f.label :public_access, class: 'control-label'
-            = f.select :public_access, [['Público', true], ['Privado', false]], {}, required: true, class: 'form-control'
+            = f.select :public_access, [['Público', true], ['Privado', false]], {}, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.public_access')}"
         .col-xs-4
           .form-group.required
             = f.label :accrual_periodicity, class: 'control-label'
-            = f.select :accrual_periodicity, iso8601_repeating_interval_options_for_select(f.object.accrual_periodicity), {}, required: true, class: 'form-control'
+            = f.select :accrual_periodicity, iso8601_repeating_interval_options_for_select(f.object.accrual_periodicity), {}, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.accrual_periodicity')}"
         .col-xs-4
           .form-group.required
             = f.label :publish_date, class: 'control-label'
-            = f.text_field :publish_date, class: 'datepicker form-control'
+            = f.text_field :publish_date, class: 'datepicker form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.publish_date')}"
       = f.button 'Guardar', type: 'submit', class: 'btn btn-primary btn-lg'
     .col-md-3
       %p

--- a/app/views/inventories/datasets/new.html.haml
+++ b/app/views/inventories/datasets/new.html.haml
@@ -71,4 +71,4 @@
     .col-md-3
       %p
         Un <strong>Recurso de datos</strong> es un archivo de Datos Abiertos que pertenece a un Conjunto de Datos. Cada Recurso de Datos puede estar disponible en diferentes estructuras (cartográfico, tabular), temporalidades (años, meses), formatos (CSV, API, RSS), agregaciones espaciales (nivel país, estatal, municipal, etc).
-  = f.button 'Publicar', type: 'submit', id: 'publish', class: 'btn btn-lg btn-primary'
+  = f.button 'Guardar', type: 'submit', id: 'publish', class: 'btn btn-lg btn-primary'

--- a/app/views/inventories/datasets/new.html.haml
+++ b/app/views/inventories/datasets/new.html.haml
@@ -8,26 +8,26 @@
       %br
       .form-group.required
         = f.label :title, class: 'control-label'
-        = f.text_field :title, required: true, class: 'form-control'
+        = f.text_field :title, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.title')}"
       .form-group.required
         = f.label :description, class: 'control-label'
-        = f.text_area :description, required: true, class: 'autosize form-control'
+        = f.text_area :description, required: true, class: 'autosize form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.description')}"
       .form-group.required
         = f.label :contact_position, class: 'control-label'
-        = f.text_field :contact_position, required: true, class: 'form-control'
+        = f.text_field :contact_position, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.contact_position')}"
       .row
         .col-xs-4
           .form-group.required
             = f.label :public_access, class: 'control-label'
-            = f.select :public_access, [['Público', true], ['Privado', false]], {}, required: true, class: 'form-control'
+            = f.select :public_access, [['Público', true], ['Privado', false]], {}, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.public_access')}"
         .col-xs-4
           .form-group.required
             = f.label :accrual_periodicity, class: 'control-label'
-            = f.select :accrual_periodicity, iso8601_repeating_interval_options_for_select(f.object.accrual_periodicity), {}, required: true, class: 'form-control'
+            = f.select :accrual_periodicity, iso8601_repeating_interval_options_for_select(f.object.accrual_periodicity), {}, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.accrual_periodicity')}"
         .col-xs-4
           .form-group.required
             = f.label :publish_date, class: 'control-label'
-            = f.text_field :publish_date, class: 'datepicker form-control'
+            = f.text_field :publish_date, class: 'datepicker form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.publish_date')}"
     .col-md-3
       %p
         Un <strong>Conjunto de datos</strong> es un grupo de Recursos de Datos Abiertos que tienen un tema en común.
@@ -41,24 +41,24 @@
           .jumbotron
             .form-group.required
               = distribution_form.label :title, class: 'control-label'
-              = distribution_form.text_field :title, required: true, class: 'form-control'
+              = distribution_form.text_field :title, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.title')}"
             .form-group.required
               = distribution_form.label :description, class: 'control-label'
-              = distribution_form.text_area :description, required: true, class: 'autosize form-control'
+              = distribution_form.text_area :description, required: true, class: 'autosize form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.description')}"
             .row
               .col-xs-6
                 .form-group.required
                   = distribution_form.label :media_type, class: 'control-label'
-                  = select_tag :media_type_select, options_for_media_type, class: 'form-control media_type_select'
+                  = select_tag :media_type_select, options_for_media_type, class: 'form-control media_type_select', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type_select')}"
               .col-xs-6
                 .form-group
                   = distribution_form.label :media_type, class: 'control-label invisible'
-                  = distribution_form.text_field :media_type, required: true, class: 'form-control media_type'
+                  = distribution_form.text_field :media_type, required: true, class: 'form-control media_type', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type')}"
             .row
               .col-xs-6
                 .form-group.required
                   = distribution_form.label :publish_date, class: 'control-label'
-                  = distribution_form.text_field :publish_date, class: 'datepicker form-control'
+                  = distribution_form.text_field :publish_date, class: 'datepicker form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
             .form-group
               = distribution_form.link_to_remove class: 'btn btn-danger pull-right' do
                 %span.icon.icon-right

--- a/app/views/inventories/distributions/edit.html.haml
+++ b/app/views/inventories/distributions/edit.html.haml
@@ -7,18 +7,18 @@
     = form_for [:inventories, @distribution.dataset, @distribution] do |f|
       .form-group.required
         = f.label :title, class: 'control-label'
-        = f.text_field :title, required: true, class: 'form-control'
+        = f.text_field :title, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.title')}"
       .form-group.required
         = f.label :description, class: 'control-label'
-        = f.text_area :description, required: true, class: 'autosize form-control'
+        = f.text_area :description, required: true, class: 'autosize form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.description')}"
       .form-group.required
         = f.label :publish_date, class: 'control-label'
-        = f.text_field :publish_date, value: f.object.publish_date&.strftime('%F'), required: true, class: 'datepicker auto_submit_item form-control'
+        = f.text_field :publish_date, value: f.object.publish_date&.strftime('%F'), required: true, class: 'datepicker auto_submit_item form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
       .form-group.required
         = f.label :media_type, class: 'control-label'
-        = select_tag :media_type_select, options_for_media_type, class: 'form-control'
+        = select_tag :media_type_select, options_for_media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type_select')}"
       .form-group
-        = f.text_field :media_type, required: true, class: 'form-control'
+        = f.text_field :media_type, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type')}"
       .form-group.required
         %label.control-label
           Campos obligatorios

--- a/app/views/inventories/distributions/new.html.haml
+++ b/app/views/inventories/distributions/new.html.haml
@@ -7,18 +7,18 @@
     = form_for [:inventories, @dataset, @distribution] do |f|
       .form-group.required
         = f.label :title, class: 'control-label'
-        = f.text_field :title, required: true, class: 'form-control'
+        = f.text_field :title, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.title')}"
       .form-group.required
         = f.label :description, class: 'control-label'
-        = f.text_area :description, required: true, class: 'autosize form-control'
+        = f.text_area :description, required: true, class: 'autosize form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.description')}"
       .form-group.required
         = f.label :publish_date, class: 'control-label'
-        = f.text_field :publish_date, value: f.object.publish_date&.strftime('%F'), required: true, class: 'datepicker auto_submit_item form-control'
+        = f.text_field :publish_date, value: f.object.publish_date&.strftime('%F'), required: true, class: 'datepicker auto_submit_item form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
       .form-group.required
         = f.label :media_type, class: 'control-label'
-        = select_tag :media_type_select, options_for_media_type, class: 'form-control'
+        = select_tag :media_type_select, options_for_media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type_select')}"
       .form-group
-        = f.text_field :media_type, required: true, class: 'form-control'
+        = f.text_field :media_type, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type')}"
       .form-group.required
         %label.control-label
           Campos obligatorios

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,8 +25,9 @@ module Adela
     # config.time_zone = 'Central Time (US & Canada)'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.i18n.default_locale = :de
+
     config.generators do |generator|
       generator.helper = false
       generator.stylesheets = false

--- a/config/locales/tooltips/forms/dataset.yml
+++ b/config/locales/tooltips/forms/dataset.yml
@@ -1,0 +1,15 @@
+es:
+  tooltip:
+    dataset:
+      title: title
+      description: description
+      contact_position: contact_position
+      public_access: public_access
+      accrual_periodicity: accrual_periodicity
+      publish_date: publish_date
+      email_field: email_field
+      spatial: spatial
+      temporal: temporal
+      landing_page: landing_page
+      sector: sector
+      keyword: keyword

--- a/config/locales/tooltips/forms/dataset.yml
+++ b/config/locales/tooltips/forms/dataset.yml
@@ -1,15 +1,15 @@
 es:
   tooltip:
     dataset:
-      title: title
-      description: description
-      contact_position: contact_position
-      public_access: public_access
-      accrual_periodicity: accrual_periodicity
-      publish_date: publish_date
-      email_field: email_field
-      spatial: spatial
-      temporal: temporal
-      landing_page: landing_page
-      sector: sector
-      keyword: keyword
+      title: Título descriptivo del Conjunto de Datos. Por ejemplo, "Programa de fomento a la agricultura","Vuelos comerciales", etc.
+      description: Una explicación detallada de los datos contenidos en el Conjunto de Datos. Por ejemplo, "Apoyos otorgados a través del programa Opciones Productivas, desglosado a nivel localidad de 2000 a 2015".
+      contact_position: Cargo de la persona de contacto que atenderá dudas y comentarios sobre el conjunto de datos. Por ejemplo, "Administrador Institucional de Datos".
+      public_access: Tipo de Datos contenidos dentro del Conjunto de Datos que se está documentando, Puede ser "Público" ó "Privado"
+      accrual_periodicity: Frecuencia con la cual el conjunto de datos será publicado o actualizado. Por ejemplo, "mensualmente"
+      publish_date: Fecha estimada de publicación del Conjunto de datos en el sitio de datos.gob.mx.
+      email_field: Correo electrónico de contacto para atender dudas y comentarios sobre el conjunto de datos.
+      spatial: Cobertura espacial del conjunto de datos. Algunos ejemplos son, "Baja California”, 002, "estatal” ó especificar un rango de coordenadas como "32.71,-112.32 27.99, -118.45”.
+      temporal: El período temporal que abarca el conjunto de datos. Algunos ejemplos son, "2013”, "2010/2012”, "2014-01/2014-04".
+      landing_page: Dirección electrónica del diccionario de datos del Conjunto. Por ejemplo, "http://www.coneval.org.mx/Informes/Coordinacion/INFORMES_Y_PUBLICACIONES_PDF/Metodologia_Multidimensional_web.pdf".
+      sector: Sector al que pertenece el Conjunto de Datos según el tema que trata.
+      keyword: Lista de términos clave separados por coma, que facilitarán al usuario la búsqueda del conjunto de datos. Es importante considerar el uso de términos no técnicos; por ejemplo, "salud", "medicinas", "compras", "agricultura", etc.

--- a/config/locales/tooltips/forms/distribution.yml
+++ b/config/locales/tooltips/forms/distribution.yml
@@ -1,0 +1,14 @@
+es:
+  tooltip:
+    distribution:
+      title: title
+      description: description
+      media_type_select: media_type_select
+      media_type: media_type
+      publish_date: publish_date
+      download_url: download_url
+      temporal:
+        init: temporal_init
+        term: temporal_term
+      modified: modified
+      byte_size: byte_size

--- a/config/locales/tooltips/forms/distribution.yml
+++ b/config/locales/tooltips/forms/distribution.yml
@@ -1,14 +1,15 @@
 es:
   tooltip:
     distribution:
-      title: title
-      description: description
-      media_type_select: media_type_select
+      title: La clave que identifica al conjunto de datos al que pertenece (y bajo el que se agrupa) este recurso. Algunos ejemplos son, "Otorgamientos del 2013”, “Otorgamientos del 2014”, “Apoyos por municipio”, “Apoyos por localidad”.
+      description: Una explicación detallada de los datos contenidos en el Recurso de Datos. Por ejemplo, “Apoyos otorgados a través del programa Opciones Productivas, desglosado a nivel localidad de 2000 a 2015”.
+      media_type_select: Formato de archivo del Recurso de Datos a descargar.
       media_type: media_type
-      publish_date: publish_date
-      download_url: download_url
+      format: El formato del archivo del recurso de datos. Algunos ejemplos son, "shp".
+      publish_date: Fecha estimada de publicación del Recurso de datos en el sitio de datos.gob.mx.
+      download_url: Dirección electrónica (enlace) para la descarga del recurso. Por ejemplo, "http://datos.sedesol.gob.mx/padronbeneficiarios/140930/sp/DIRECTORIO_OSC.csv".
       temporal:
-        init: temporal_init
-        term: temporal_term
-      modified: modified
-      byte_size: byte_size
+        init: Inicio del período temporal que abarca el recurso de datos. Algunos ejemplos son, "2013”, "2014-01", etc.
+        term: Fin del período temporal que abarca el recurso de datos. Algunos ejemplos son, "2014”, "2014-04", etc.
+      modified: La fecha más reciente en la que se modificó, cambió o actualizó el Recurso de Datos
+      byte_size: El tamaño en bytes del recurso o archivo descargable. Por ejemplo, "24.2 MB"

--- a/spec/features/user_manages_inventory_datasets_crud_spec.rb
+++ b/spec/features/user_manages_inventory_datasets_crud_spec.rb
@@ -18,7 +18,7 @@ feature User, 'manages inventory datasets crud:' do
 
     click_on('Agregar un recurso nuevo')
     fill_distribution_nested_form(distribution_attributes)
-    click_on('Publicar')
+    click_on('Guardar')
 
     expect(current_path).to eq(inventories_path)
     find('tr.dataset td a.accordion-toggle', text: dataset_attributes[:title]).click
@@ -46,7 +46,7 @@ feature User, 'manages inventory datasets crud:' do
     fill_private_dataset_form(dataset_attributes)
     click_on('Agregar un recurso nuevo')
     fill_distribution_nested_form(distribution_attributes)
-    click_on('Publicar')
+    click_on('Guardar')
 
     find('tr.dataset td a.accordion-toggle', text: dataset_attributes[:title]).click
 
@@ -176,7 +176,7 @@ feature User, 'manages inventory datasets crud:' do
     fill_public_dataset_form(dataset)
     click_on('Agregar un recurso nuevo')
     fill_distribution_nested_form(distribution)
-    click_on('Publicar')
+    click_on('Guardar')
 
     dataset
   end


### PR DESCRIPTION
# WIP
* Falta agregar los textos de los tooltips

### Changelog
1. En el Inventario de Datos, se agregan tooltips a los formularios de los Conjuntos de Datos y Recursos. 
1. En el Catálogo de Datos, se agregan tooltips a los formularios de los Conjuntos de Datos y Recursos.

### How to Test
1. En el Inventario de Datos, pasar el mouse sobre los inputs del formulario de Conjuntos de Datos y distribuciónes.
1. En el Catálogo de Datos, pasar el mouse sobre los inputs del formulario de Conjuntos de Datos y distribuciónes.

Closes #470 
Closes #934 
Closes #935 
Closes #936 
Closes #937 
