### PR TITLE
Autofills the distribution publish date with the dataset publish date

### DIFF
--- a/app/assets/javascripts/datasets.js
+++ b/app/assets/javascripts/datasets.js
@@ -26,21 +26,27 @@ $(function () {
 });
 
 $(document).on('nested:fieldAdded', function(event){
-    var updateMediaType;
-    (updateMediaType = function () {
-      var mediaType = event.field.find('.form-group .media_type_select option:selected').val();
-      var format = event.field.find('.form-group .media_type_select option:selected').text();
+    var updateMediaType, datasetPublishDate;
 
-      if (format === 'otro') {
+    (updateMediaType = function() {
+      var mediaType = event.field.find('.form-group .media_type_select');
+      var inputText = event.field.find('.form-group input.media_type');
+      var format    = event.field.find('.form-group .media_type_select option:selected').text();
+
+      if (format == 'otro') {
         event.field.find('.form-group input.media_type').val('');
         event.field.find('.form-group input.format').val('');
         event.field.find('.form-group input.format').parent().show();
       } else {
-        event.field.find('.form-group input.media_type').val(mediaType);
+        event.field.find('.form-group input.media_type').val(mediaType.val());
         event.field.find('.form-group input.format').val(format);
         event.field.find('.form-group input.format').parent().hide();
       }
     })();
+
+    // sets dataset publish-date into new distribution
+    datasetPublishDate = $('#dataset_publish_date').val();
+    event.field.find('.publish-date').val(datasetPublishDate);
 
     $('.media_type_select').on('change', updateMediaType);
     $('.datepicker').datepicker();

--- a/app/views/inventories/datasets/new.html.haml
+++ b/app/views/inventories/datasets/new.html.haml
@@ -58,7 +58,7 @@
               .col-xs-6
                 .form-group.required
                   = distribution_form.label :publish_date, class: 'control-label'
-                  = distribution_form.text_field :publish_date, class: 'datepicker form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
+                  = distribution_form.text_field :publish_date, class: 'datepicker publish-date form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
               .col-xs-6
                 .form-group
                   = distribution_form.hidden_field :media_type, class: 'form-control media_type'

--- a/app/views/inventories/distributions/new.html.haml
+++ b/app/views/inventories/distributions/new.html.haml
@@ -13,7 +13,7 @@
         = f.text_area :description, required: true, class: 'autosize form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.description')}"
       .form-group.required
         = f.label :publish_date, class: 'control-label'
-        = f.text_field :publish_date, value: f.object.publish_date&.strftime('%F'), required: true, class: 'datepicker auto_submit_item form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
+        = f.text_field :publish_date, value: @dataset.publish_date&.strftime('%F'), required: true, class: 'datepicker auto_submit_item form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
       .form-group.required
         = f.label :media_type, class: 'control-label'
         = select_tag :media_type_select, options_for_media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type_select')}"


### PR DESCRIPTION
### Changelog
1. En el Inventario de Datos, al agregar un nuevo recurso, el campo `publish_date` de un recurso se obtiene del `publish_date` del conjunto de datos (si este existe).

### How to Test
1. En el Inventario de Datos y agregar un Conjunto de Datos. Llenar el campo "Fecha de publicación" antes de agregar recursos y verificar que se pre llene el valor.
1. Agregar un recurso a un conjunto y verificar que salga la fecha de publicación.

Closes #938 
