### PR TITLE
Media type refinement

### DIFF
--- a/app/assets/javascripts/datasets.js
+++ b/app/assets/javascripts/datasets.js
@@ -27,16 +27,18 @@ $(function () {
 
 $(document).on('nested:fieldAdded', function(event){
     var updateMediaType;
-    (updateMediaType = function() {
-      var mediaType = event.field.find('.form-group .media_type_select');
-      var inputText = event.field.find('.form-group input.media_type');
+    (updateMediaType = function () {
+      var mediaType = event.field.find('.form-group .media_type_select option:selected').val();
+      var format = event.field.find('.form-group .media_type_select option:selected').text();
 
-      inputText.val(mediaType.val());
-      if (mediaType.val() == 'otro') {
-        inputText.val('');
-        inputText.show();
+      if (format === 'otro') {
+        event.field.find('.form-group input.media_type').val('');
+        event.field.find('.form-group input.format').val('');
+        event.field.find('.form-group input.format').parent().show();
       } else {
-        inputText.hide();
+        event.field.find('.form-group input.media_type').val(mediaType);
+        event.field.find('.form-group input.format').val(format);
+        event.field.find('.form-group input.format').parent().hide();
       }
     })();
 

--- a/app/assets/javascripts/distributions.js
+++ b/app/assets/javascripts/distributions.js
@@ -1,36 +1,47 @@
-$(function () {
-  var initMediaType;
-  (initMediaType = function() {
-    var mediaType = $('#distribution_media_type').val();
-
-    var containsMediaType = function() {
-      return $("#media_type_select option[value='" + mediaType + "']").length > 0;
-    }
-
-    if (!mediaType) {
-      $('#distribution_media_type').val($('#media_type_select').val());
-      $('#distribution_media_type').hide();
-    } else if (containsMediaType()) {
-      $('#distribution_media_type').hide();
-      $('#media_type_select').val(mediaType);
-    } else {
-      $('#media_type_select').val('otro');
-      $('#distribution_media_type').val(mediaType);
-    }
-  })();
-
-  var updateMediaType = function() {
-    var mediaType = $('#media_type_select').val();
-    $('#distribution_media_type').val(mediaType);
-    if (mediaType == 'otro') {
-      $('#distribution_media_type').val('');
-      $('#distribution_media_type').show();
-    } else {
-      $('#distribution_media_type').hide();
-    }
-  };
-
+ $(function () {
+  var optionValues = [];
   (function () {
-    $('#media_type_select').change(updateMediaType);
+    $("#media_type_select option").each(function() {
+      var value = $(this).text();
+      if (value === "otro") { return };
+      optionValues.push(value);
+    });
   })();
+
+  var initMediaType;
+  (updateMediaType = function () {
+    var format = $("#distribution_format");
+    var mediaType = $("#distribution_media_type")
+
+    if ($.inArray(format.val(), optionValues) !== -1) {
+      $('#distribution_format').parent().hide();
+      $("#media_type_select").val(mediaType.val());
+      $('#distribution_format').val(format.val());
+      $('#distribution_media_type').val(mediaType.val());
+    } else {
+      $('#distribution_format').parent().show();
+      $('#media_type_select option')
+        .filter(function () { return $(this).html() == "otro"; })
+        .attr("selected", true);
+    }
+  })();
+
+  var updateMediaType;
+  updateMediaType = function () {
+    var select = $('#media_type_select option:selected');
+    var mediaType = select.val();
+    var format = select.text();
+
+    if ($.inArray(format, optionValues) !== -1) {
+      $('#distribution_format').parent().hide();
+      $('#distribution_format').val(format);
+      $('#distribution_media_type').val(mediaType);
+    } else {
+      $('#distribution_format').parent().show();
+      $('#distribution_format').val('');
+      $('#distribution_media_type').val('');
+    }
+  }
+
+  $('#media_type_select').change(updateMediaType);
 });

--- a/app/controllers/inventories/datasets_controller.rb
+++ b/app/controllers/inventories/datasets_controller.rb
@@ -33,7 +33,7 @@ class Inventories::DatasetsController < ApplicationController
       :public_access,
       :accrual_periodicity,
       :publish_date,
-      distributions_attributes: [:id, :title, :description, :publish_date, :media_type, :_destroy]
+      distributions_attributes: [:id, :title, :description, :publish_date, :media_type, :format, :_destroy]
     )
   end
 end

--- a/app/controllers/inventories/distributions_controller.rb
+++ b/app/controllers/inventories/distributions_controller.rb
@@ -24,6 +24,6 @@ class Inventories::DistributionsController < ApplicationController
   end
 
   def distribution_params
-    params.require(:distribution).permit(:title, :description, :publish_date, :media_type)
+    params.require(:distribution).permit(:title, :description, :publish_date, :media_type, :format)
   end
 end

--- a/app/helpers/distributions_helper.rb
+++ b/app/helpers/distributions_helper.rb
@@ -4,7 +4,7 @@ module DistributionsHelper
   end
 
   def options_for_media_type
-    options_for_select(I18n.t('media_type').invert)
+    options_for_select(I18n.t('media_type'))
   end
 
   def state_description(distribution)

--- a/app/serializers/distribution_serializer.rb
+++ b/app/serializers/distribution_serializer.rb
@@ -1,6 +1,6 @@
 class DistributionSerializer < ActiveModel::Serializer
   attributes :title, :description, :downloadURL, :mediaType, :byteSize,
-             :temporal, :spatial, :license, :issued
+             :temporal, :spatial, :license, :issued, :format
 
   def license
     'http://datos.gob.mx/libreusomx/'

--- a/app/views/inventories/datasets/new.html.haml
+++ b/app/views/inventories/datasets/new.html.haml
@@ -51,14 +51,17 @@
                   = distribution_form.label :media_type, class: 'control-label'
                   = select_tag :media_type_select, options_for_media_type, class: 'form-control media_type_select', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type_select')}"
               .col-xs-6
-                .form-group
-                  = distribution_form.label :media_type, class: 'control-label invisible'
-                  = distribution_form.text_field :media_type, required: true, class: 'form-control media_type', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type')}"
+                .form-group.required
+                  = distribution_form.label :format, class: 'control-label'
+                  = distribution_form.text_field :format, required: true, class: 'format form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.format')}"
             .row
               .col-xs-6
                 .form-group.required
                   = distribution_form.label :publish_date, class: 'control-label'
                   = distribution_form.text_field :publish_date, class: 'datepicker form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
+              .col-xs-6
+                .form-group
+                  = distribution_form.hidden_field :media_type, class: 'form-control media_type'
             .form-group
               = distribution_form.link_to_remove class: 'btn btn-danger pull-right' do
                 %span.icon.icon-right

--- a/app/views/inventories/distributions/edit.html.haml
+++ b/app/views/inventories/distributions/edit.html.haml
@@ -17,8 +17,10 @@
       .form-group.required
         = f.label :media_type, class: 'control-label'
         = select_tag :media_type_select, options_for_media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type_select')}"
+        = f.hidden_field :media_type, value: f.object.media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type')}"
       .form-group
-        = f.text_field :media_type, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type')}"
+        = f.label :format, class: 'control-label'
+        = f.text_field :format, value: f.object.format, required: true, class: 'form-control'
       .form-group.required
         %label.control-label
           Campos obligatorios

--- a/app/views/inventories/distributions/new.html.haml
+++ b/app/views/inventories/distributions/new.html.haml
@@ -17,8 +17,10 @@
       .form-group.required
         = f.label :media_type, class: 'control-label'
         = select_tag :media_type_select, options_for_media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type_select')}"
+        = f.hidden_field :media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type')}"
       .form-group
-        = f.text_field :media_type, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type')}"
+        = f.label :format, class: 'control-label'
+        = f.text_field :format, required: true, class: 'form-control'
       .form-group.required
         %label.control-label
           Campos obligatorios

--- a/app/views/inventories/shared/_distribution.html.haml
+++ b/app/views/inventories/shared/_distribution.html.haml
@@ -3,7 +3,7 @@
   %td.nested
     = distribution.title
     %span.label.label-default.media-type
-      = distribution.media_type
+      = distribution.format
   %td
   %td.center
     = distribution.publish_date&.strftime('%F')

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -130,6 +130,7 @@ es:
         description: 'Descripción del Recurso'
         publish_date: 'Fecha de publicación'
         media_type: 'Formato del recurso'
+        format: 'Extensión del recurso'
       organization:
         title: "Nombre"
         description: "Descripción"

--- a/config/locales/media_type.en.yml
+++ b/config/locales/media_type.en.yml
@@ -1,9 +1,0 @@
-en:
-  media_type:
-    csv: 'csv'
-    excel: 'excel'
-    json: 'json'
-    kml: 'kml'
-    shp: 'shp'
-    kmz: 'kmz'
-    otro: 'otro'

--- a/config/locales/media_type.es.yml
+++ b/config/locales/media_type.es.yml
@@ -1,9 +1,9 @@
 es:
   media_type:
-    csv: 'csv'
-    excel: 'excel'
-    json: 'json'
-    kml: 'kml'
-    shp: 'shp'
-    kmz: 'kmz'
-    otro: 'otro'
+    csv: 'text/csv'
+    xls: 'application/vnd.ms-excel'
+    json: 'application/json'
+    kml: 'application/vnd.google-earth.kml+xml'
+    shp: ''
+    kmz: 'application/vnd.google-earth.kmz'
+    otro: ''

--- a/db/migrate/20160509031025_add_format_to_distribution.rb
+++ b/db/migrate/20160509031025_add_format_to_distribution.rb
@@ -1,0 +1,5 @@
+class AddFormatToDistribution < ActiveRecord::Migration
+  def change
+    add_column :distributions, :format, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160425131934) do
+ActiveRecord::Schema.define(version: 20160509031025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 20160425131934) do
     t.string   "state"
     t.datetime "issued"
     t.datetime "publish_date"
+    t.string   "format"
   end
 
   add_index "distributions", ["dataset_id"], name: "index_distributions_on_dataset_id", using: :btree

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     spatial { Faker::Address.state }
     issued {  Faker::Time.forward }
     publish_date { Time.current }
+    format { Faker::App.name.downcase }
     dataset
 
     factory :catalog_distribution do

--- a/spec/requests/data_catalog_management_spec.rb
+++ b/spec/requests/data_catalog_management_spec.rb
@@ -42,7 +42,7 @@ feature 'data catalog management' do
 
     dcat_keys = %w(title description homepage issued modified language license dataset)
     dcat_dataset_keys = %w(identifier title description keyword modified contactPoint spatial landingPage language publisher distribution temporal issued)
-    dcat_distribution_keys = %w(title description license downloadURL mediaType byteSize temporal spatial issued)
+    dcat_distribution_keys = %w(title description license downloadURL mediaType byteSize temporal spatial issued format)
 
     get "/#{organization.slug}/catalogo.json"
     json_response = JSON.parse(response.body)


### PR DESCRIPTION
### Changelog
1. Se agrega el campo `dct:format` a los recursos.
1. Se cambia el select del campo `dcat:media_type` por los MIME Types.

### How to Test
1. En el Inventario de Datos, agregar un conjunto de datos con recursos.
1. Publicar el Catalogo de Datos y verificar que se muestren los campos nuevos.

Closes #900 