### PR TITLE
Nombre del Responsable

### DIFF
--- a/app/controllers/api/v1/datasets_controller.rb
+++ b/app/controllers/api/v1/datasets_controller.rb
@@ -8,8 +8,9 @@ class Api::V1::DatasetsController < ApplicationController
 
   def vcard(dataset)
     vcard = VCardigan.create
-    vcard.fullname dataset.contact_position
-    vcard.email dataset.mbox, type: ['work', 'internet'], preferred: 1
+    vcard.name dataset.contact_position
+    vcard.fullname dataset.contact_name
+    vcard.email dataset.mbox, type: %w(work internet), preferred: 1
     vcard
   end
 end

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -25,6 +25,7 @@ class DatasetsController < ApplicationController
       :description,
       :publish_date,
       :accrual_periodicity,
+      :contact_name,
       :contact_position,
       :mbox,
       :landing_page,

--- a/app/views/datasets/edit.html.haml
+++ b/app/views/datasets/edit.html.haml
@@ -20,6 +20,9 @@
           .form-group.required
             = f.label :publish_date, class: 'control-label'
             = f.text_field :publish_date, value: f.object.publish_date.strftime('%F'), class: 'datepicker auto_submit_item form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.publish_date')}"
+      .form-group
+        = f.label :contact_name, class: 'control-label'
+        = f.text_field :contact_name, class: 'auto_submit_item form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.contact_name')}"
       .row
         .col-xs-6
           .form-group.required

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -119,6 +119,7 @@ es:
       dataset:
         title: 'Nombre del Conjunto de Datos'
         description: 'Descripción'
+        contact_name: 'Nombre del responsable'
         contact_position: 'Cargo del funcionario responsable de publicar el Conjunto de Datos'
         public_access: '¿Tiene datos privados?'
         accrual_periodicity: 'Frecuencia con la que actualizan'

--- a/config/locales/tooltips/forms/dataset.yml
+++ b/config/locales/tooltips/forms/dataset.yml
@@ -3,6 +3,7 @@ es:
     dataset:
       title: Título descriptivo del Conjunto de Datos. Por ejemplo, "Programa de fomento a la agricultura","Vuelos comerciales", etc.
       description: Una explicación detallada de los datos contenidos en el Conjunto de Datos. Por ejemplo, "Apoyos otorgados a través del programa Opciones Productivas, desglosado a nivel localidad de 2000 a 2015".
+      contact_name: Nombre del contacto que atenderá dudas y comentarios sobre el conjunto de datos.
       contact_position: Cargo de la persona de contacto que atenderá dudas y comentarios sobre el conjunto de datos. Por ejemplo, "Administrador Institucional de Datos".
       public_access: Tipo de Datos contenidos dentro del Conjunto de Datos que se está documentando, Puede ser "Público" ó "Privado"
       accrual_periodicity: Frecuencia con la cual el conjunto de datos será publicado o actualizado. Por ejemplo, "mensualmente"

--- a/db/migrate/20160510041806_add_contact_name_to_dataset.rb
+++ b/db/migrate/20160510041806_add_contact_name_to_dataset.rb
@@ -1,0 +1,5 @@
+class AddContactNameToDataset < ActiveRecord::Migration
+  def change
+    add_column :datasets, :contact_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160509031025) do
+ActiveRecord::Schema.define(version: 20160510041806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 20160509031025) do
     t.boolean  "public_access",       default: true
     t.boolean  "editable",            default: true
     t.datetime "issued"
+    t.string   "contact_name"
   end
 
   add_index "datasets", ["catalog_id"], name: "index_datasets_on_catalog_id", using: :btree

--- a/spec/controllers/api/v1/datasets_controller_spec.rb
+++ b/spec/controllers/api/v1/datasets_controller_spec.rb
@@ -9,7 +9,7 @@ describe Api::V1::DatasetsController do
     it 'downloads the dataset contact point vcard' do
       get :contact_point, id: @dataset.id, locale: :es
       expect(response.body).to eq(
-        "BEGIN:VCARD\nVERSION:4.0\nFN:#{@dataset.contact_position}\nEMAIL;TYPE=[\"work\", \"internet\"];PREF=1:#{@dataset.mbox}\nEND:VCARD\n"
+        "BEGIN:VCARD\nVERSION:4.0\nN:#{@dataset.contact_position};;;;\nFN:#{@dataset.contact_name}\nEMAIL;TYPE=[\"work\", \"internet\"];PREF=1:#{@dataset.mbox}\nEND:VCARD\n"
       )
     end
   end

--- a/spec/factories/datasets.rb
+++ b/spec/factories/datasets.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     keyword { Faker::Lorem.words.join(',') }
     modified { Faker::Time.forward }
     contact_position { Faker::Company.profession }
+    contact_name { Faker::Name.name }
     mbox { Faker::Internet.email }
     temporal { "#{Faker::Date.backward.iso8601}/#{Faker::Date.forward.iso8601}" }
     spatial { "#{Faker::Address.latitude}/#{Faker::Address.longitude}" }


### PR DESCRIPTION
### Changelog
1. Se agrega el campo `contact_name` para llenar el nombre del funcionario (opcional).
1. Se agrefa el `contact_name` dentro de la vcard que genera Adela.

### How to Test
1. Documentar el campo `contact_name` en algun conjunto de datos.
1. Publicar el Catálogo de Datos.
1. Verificar la API del Catálogo de Datos de la organización.

Closes #909 