### PR TITLE
Inventory API Endpoint

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -10,6 +10,13 @@ module Api
         render json: @organization, root: false
       end
 
+      def inventory
+        @organization = Organization.friendly.find(params[:id])
+        respond_to do |format|
+          format.json { render json: @organization.catalog, serializer: InventoriesSerializer, root: false }
+        end
+      end
+
       def catalogs
         @catalogs_urls = Organization.all.select do |organization|
           organization.catalog.present? && organization.catalog.distributions.map(&:published?).any?

--- a/app/serializers/inventories/datasets_serializer.rb
+++ b/app/serializers/inventories/datasets_serializer.rb
@@ -1,0 +1,20 @@
+class Inventories::DatasetsSerializer < ActiveModel::Serializer
+  has_many :distributions, root: :distribution, serializer: Inventories::DistributionsSerializer
+  attributes :identifier, :title, :description, :modified, :contactPoint, :spatial, :issued, :temporal
+
+  def attributes
+    data = super
+    data[:language] = 'es'
+    data[:publisher] = {
+      name: object.publisher,
+      mbox: object.mbox
+    }
+    data[:keyword] = object.keywords.split(',').map(&:squish)
+    data[:landingPage] = object.landing_page
+    data
+  end
+
+  def contactPoint
+    "http://adela.datos.gob.mx/api/v1/datasets/#{object.id}/contact_point.vcf"
+  end
+end

--- a/app/serializers/inventories/distributions_serializer.rb
+++ b/app/serializers/inventories/distributions_serializer.rb
@@ -1,0 +1,20 @@
+class Inventories::DistributionsSerializer < ActiveModel::Serializer
+  attributes :title, :description, :downloadURL, :mediaType, :byteSize, :temporal, :spatial,
+             :license, :issued
+
+  def license
+    'http://datos.gob.mx/libreusomx/'
+  end
+
+  def downloadURL
+    object.download_url
+  end
+
+  def mediaType
+    object.media_type
+  end
+
+  def byteSize
+    object.byte_size
+  end
+end

--- a/app/serializers/inventories_serializer.rb
+++ b/app/serializers/inventories_serializer.rb
@@ -1,0 +1,9 @@
+class InventoriesSerializer < ActiveModel::Serializer
+  has_many :datasets, root: :dataset, serializer: Inventories::DatasetsSerializer
+
+  def attributes
+    data ||= {}
+    data[:title] = "Inventario de Datos de #{object.organization.title}"
+    data.merge super
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Adela::Application.routes.draw do
       end
 
       resources :organizations, only: [:show] do
+        get 'inventory', on: :member
         collection do
           get 'catalogs'
           get 'organizations'

--- a/spec/requests/data_inventory_management_spec.rb
+++ b/spec/requests/data_inventory_management_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+feature 'data inventory management' do
+  let(:organization) { create(:organization) }
+
+  scenario 'can consume published catalog data' do
+    catalog = create(:catalog, organization: organization)
+    dataset = create(:dataset, catalog: catalog)
+    create(:distribution, dataset: dataset)
+
+    get "/api/v1/organizations/#{organization.slug}/inventory.json"
+    json_response = JSON.parse(response.body)
+    expect(json_response['title']).to eql("Inventario de Datos de #{organization.title}")
+    expect(json_response['dataset']).not_to be_empty
+  end
+
+  scenario 'catalog will have correct DCAT key names' do
+    catalog = create(:catalog, organization: organization)
+    dataset = create(:dataset, catalog: catalog)
+    create(:distribution, dataset: dataset)
+
+    dcat_keys = %w(title dataset)
+    dcat_dataset_keys = %w(identifier title description keyword modified contactPoint spatial landingPage language publisher distribution temporal issued)
+    dcat_distribution_keys = %w(title description license downloadURL mediaType byteSize temporal spatial issued)
+
+    get "/api/v1/organizations/#{organization.slug}/inventory.json"
+    json_response = JSON.parse(response.body)
+
+    expect(json_response.keys).to eq(dcat_keys)
+    expect(json_response['dataset'].last.keys.sort).to eq(dcat_dataset_keys.sort)
+    expect(json_response['dataset'].last['distribution'].last.keys.sort).to eq(dcat_distribution_keys.sort)
+  end
+end


### PR DESCRIPTION
### Changelog
1. Agrega el endpoint `/api/v1/organizations/:slug:/inventory.json` para consumir el inventario de datos de una organización.

### How to Test
1. Agrega Conjuntos de Datos al Inventario y consume el endpoint `/api/v1/organizations/:slug:/inventory.json`.

Closes #954 