### PR TITLE
Increases font weight in table headers

### DIFF
--- a/app/assets/stylesheets/elements/_table.scss
+++ b/app/assets/stylesheets/elements/_table.scss
@@ -1,5 +1,5 @@
 .table thead > tr > th {
-  font-weight: 300;
+  font-weight: 700;
 }
 
 .table tbody > tr.active > td {


### PR DESCRIPTION
### Changelog
* Se ponen los headers de las tablas en negritas

### How to Test

1. Ingresa al Inventario de Datos
2. Ingresa al Catalogo de Datos

<img width="1552" alt="captura de pantalla 2016-05-19 a las 4 07 58 p m" src="https://cloud.githubusercontent.com/assets/764518/15410465/83a318f4-1ddf-11e6-908a-30f4fb178213.png">

Closes #962
Closes #961