### PR TITLE
Edit distribution publish date and title 

### DIFF
--- a/app/assets/stylesheets/components/_labels.scss
+++ b/app/assets/stylesheets/components/_labels.scss
@@ -4,7 +4,8 @@
   font-size: 12;
 
   &.media-type {
-    margin-left: 10px;
+    margin-top: 5px;
+    margin-right: 10px;
   }
 
   &.label-default {

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -15,6 +15,6 @@ class DistributionsController < ApplicationController
   private
 
   def distribution_params
-    params.require(:distribution).permit(:title, :publish_date, :download_url, :modified, :temporal, :byte_size)
+    params.require(:distribution).permit(:title, :description, :publish_date, :download_url, :modified, :temporal, :byte_size)
   end
 end

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -15,6 +15,6 @@ class DistributionsController < ApplicationController
   private
 
   def distribution_params
-    params.require(:distribution).permit(:download_url, :modified, :temporal, :byte_size)
+    params.require(:distribution).permit(:title, :publish_date, :download_url, :modified, :temporal, :byte_size)
   end
 end

--- a/app/views/distributions/edit.html.haml
+++ b/app/views/distributions/edit.html.haml
@@ -9,6 +9,9 @@
         = f.label :title, class: 'control-label'
         = f.text_field :title, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.title')}"
       .form-group.required
+        = f.label :description, class: 'control-label'
+        = f.text_area :description, required: true, class: 'autosize form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.description')}"
+      .form-group.required
         = f.label :download_url, 'URL para descargar'
         = f.url_field :download_url, class: 'form-control', required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.download_url')}"
       .row

--- a/app/views/distributions/edit.html.haml
+++ b/app/views/distributions/edit.html.haml
@@ -6,6 +6,9 @@
   .col-md-9
     = form_for(@distribution) do |f|
       .form-group.required
+        = f.label :title, class: 'control-label'
+        = f.text_field :title, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.title')}"
+      .form-group.required
         = f.label :download_url, 'URL para descargar'
         = f.url_field :download_url, class: 'form-control', required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.download_url')}"
       .row
@@ -27,18 +30,18 @@
           .form-group.required
             = f.label :byte_size, 'Tamaño en Bytes'
             = f.text_field :byte_size,  class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.byte_size')}"
-
+      .row
+        .col-xs-6
+          - unless @distribution.issued?
+            .form-group.required
+              = f.label :publish_date, class: 'control-label'
+              = f.text_field :publish_date, value: f.object.publish_date&.strftime('%F'), required: true, class: 'datepicker auto_submit_item form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
       = f.button 'Guardar avance', type: 'submit', class: 'btn btn-primary btn-lg pull-right'
       = link_to 'Cancelar', edit_dataset_path(@distribution.dataset), class: 'btn btn-alt btn-lg'
       .clearfix
   .col-md-3
     %p
       Los metadatos ayudan a que los usuarios entiendan las características de la información que se está publicando. La documentación es importante porque afecta la calidad de los datos y el potencial de su uso e impacto.
-    %p
-      <strong>Nombre del recurso:</strong> #{@distribution.title}
-    %p
-      <strong>Fecha compromiso de publicación:</strong> #{@distribution.dataset.publish_date.strftime('%F')}
-
 :javascript
   $(function () {
     $("form").validate({

--- a/app/views/inventories/shared/_distribution.html.haml
+++ b/app/views/inventories/shared/_distribution.html.haml
@@ -1,7 +1,7 @@
 %tr.distribution.accordion-body.collapse{'class' => "dataset_#{distribution.dataset.id}_distributions"}
   %td
   %td.nested
-    = distribution.title
+    .distribution-title= distribution.title
     %span.label.label-default.media-type
       = distribution.format
   %td


### PR DESCRIPTION
### Changelog
* Updates the `title` and `publish_date` fields into the `distribution#dataset` form.

### How to Test
1. Editar un recurso en el catálogo de datos.

<img width="1549" alt="captura de pantalla 2016-05-26 a las 5 00 57 p m" src="https://cloud.githubusercontent.com/assets/764518/15591570/729c401a-2363-11e6-8e13-82a86a936fab.png">


Closes #967 
