### PR TITLE
Catalog Versioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem 'as_csv', '~> 2.0'
 gem 'vcardigan'
 gem 'inline_svg'
 gem 'polymer-rails'
+gem 'audited-activerecord'
 
 group :development, :test do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,11 @@ GEM
       actionpack (>= 3.0)
       activemodel (>= 3.0)
       responders
+    audited (4.2.0)
+      rails-observers (~> 0.1.2)
+    audited-activerecord (4.2.0)
+      activerecord (~> 4.0)
+      audited (= 4.2.0)
     autoprefixer-rails (6.3.6)
       execjs
     autosize-rails (1.18.17)
@@ -237,6 +242,8 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails-observers (0.1.2)
+      activemodel (~> 4.0)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -382,6 +389,7 @@ DEPENDENCIES
   active_model_serializers
   active_model_warnings
   as_csv (~> 2.0)
+  audited-activerecord
   autosize-rails
   babosa
   bootstrap-sass

--- a/app/models/catalog.rb
+++ b/app/models/catalog.rb
@@ -1,8 +1,6 @@
 class Catalog < ActiveRecord::Base
   include Loggable
-
   has_associated_audits
-  audited
 
   belongs_to :organization
 

--- a/app/models/catalog.rb
+++ b/app/models/catalog.rb
@@ -1,6 +1,9 @@
 class Catalog < ActiveRecord::Base
   include Loggable
 
+  has_associated_audits
+  audited
+
   belongs_to :organization
 
   has_many :datasets, dependent: :destroy

--- a/app/models/catalog_version.rb
+++ b/app/models/catalog_version.rb
@@ -1,0 +1,4 @@
+class CatalogVersion < ActiveRecord::Base
+  belongs_to :catalog
+  validates :catalog, :version, presence: true
+end

--- a/app/models/concerns/versionable.rb
+++ b/app/models/concerns/versionable.rb
@@ -1,0 +1,17 @@
+module Versionable
+  extend ActiveSupport::Concern
+
+  included do
+    after_commit :add_catalog_version
+  end
+
+  private
+
+  def add_catalog_version
+    CatalogVersion.create(catalog: catalog, version: catalog_serializable_hash)
+  end
+
+  def catalog_serializable_hash
+    InventoriesSerializer.new(catalog).serializable_hash
+  end
+end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -1,6 +1,9 @@
 class Dataset < ActiveRecord::Base
   belongs_to :catalog
 
+  has_associated_audits
+  audited associated_with: :catalog
+
   has_many :distributions, dependent: :destroy
 
   has_one :dataset_sector, dependent: :destroy

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -1,4 +1,6 @@
 class Dataset < ActiveRecord::Base
+  include Versionable
+
   belongs_to :catalog
 
   has_associated_audits

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -1,5 +1,6 @@
 class Distribution < ActiveRecord::Base
   belongs_to :dataset
+  audited associated_with: :dataset
   validate :mandatory_fields
 
   before_save :fix_distribution

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -1,7 +1,11 @@
 class Distribution < ActiveRecord::Base
+  include Versionable
+
   belongs_to :dataset
   audited associated_with: :dataset
   validate :mandatory_fields
+
+  has_one :catalog, through: :dataset
 
   before_save :fix_distribution
   before_save :break_distibution

--- a/db/migrate/20160606143226_install_audited.rb
+++ b/db/migrate/20160606143226_install_audited.rb
@@ -1,0 +1,30 @@
+class InstallAudited < ActiveRecord::Migration
+  def self.up
+    create_table :audits, :force => true do |t|
+      t.column :auditable_id, :integer
+      t.column :auditable_type, :string
+      t.column :associated_id, :integer
+      t.column :associated_type, :string
+      t.column :user_id, :integer
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :text
+      t.column :version, :integer, :default => 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.column :created_at, :datetime
+    end
+
+    add_index :audits, [:auditable_id, :auditable_type], :name => 'auditable_index'
+    add_index :audits, [:associated_id, :associated_type], :name => 'associated_index'
+    add_index :audits, [:user_id, :user_type], :name => 'user_index'
+    add_index :audits, :request_uuid
+    add_index :audits, :created_at
+  end
+
+  def self.down
+    drop_table :audits
+  end
+end

--- a/db/migrate/20160606181544_create_catalog_versions.rb
+++ b/db/migrate/20160606181544_create_catalog_versions.rb
@@ -1,0 +1,10 @@
+class CreateCatalogVersions < ActiveRecord::Migration
+  def change
+    create_table :catalog_versions do |t|
+      t.references :catalog, index: true, foreign_key: true
+      t.json :version
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160606143226) do
+ActiveRecord::Schema.define(version: 20160606181544) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,15 @@ ActiveRecord::Schema.define(version: 20160606143226) do
   add_index "audits", ["created_at"], name: "index_audits_on_created_at", using: :btree
   add_index "audits", ["request_uuid"], name: "index_audits_on_request_uuid", using: :btree
   add_index "audits", ["user_id", "user_type"], name: "user_index", using: :btree
+
+  create_table "catalog_versions", force: :cascade do |t|
+    t.integer  "catalog_id"
+    t.json     "version"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "catalog_versions", ["catalog_id"], name: "index_catalog_versions_on_catalog_id", using: :btree
 
   create_table "catalogs", force: :cascade do |t|
     t.integer  "organization_id"
@@ -235,6 +244,7 @@ ActiveRecord::Schema.define(version: 20160606143226) do
 
   add_index "users_roles", ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id", using: :btree
 
+  add_foreign_key "catalog_versions", "catalogs"
   add_foreign_key "designation_files", "organizations"
   add_foreign_key "memo_files", "organizations"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160510041806) do
+ActiveRecord::Schema.define(version: 20160606143226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,13 +38,36 @@ ActiveRecord::Schema.define(version: 20160510041806) do
   add_index "administrators", ["organization_id"], name: "index_administrators_on_organization_id", using: :btree
   add_index "administrators", ["user_id"], name: "index_administrators_on_user_id", using: :btree
 
+  create_table "audits", force: :cascade do |t|
+    t.integer  "auditable_id"
+    t.string   "auditable_type"
+    t.integer  "associated_id"
+    t.string   "associated_type"
+    t.integer  "user_id"
+    t.string   "user_type"
+    t.string   "username"
+    t.string   "action"
+    t.text     "audited_changes"
+    t.integer  "version",         default: 0
+    t.string   "comment"
+    t.string   "remote_address"
+    t.string   "request_uuid"
+    t.datetime "created_at"
+  end
+
+  add_index "audits", ["associated_id", "associated_type"], name: "associated_index", using: :btree
+  add_index "audits", ["auditable_id", "auditable_type"], name: "auditable_index", using: :btree
+  add_index "audits", ["created_at"], name: "index_audits_on_created_at", using: :btree
+  add_index "audits", ["request_uuid"], name: "index_audits_on_request_uuid", using: :btree
+  add_index "audits", ["user_id", "user_type"], name: "user_index", using: :btree
+
   create_table "catalogs", force: :cascade do |t|
     t.integer  "organization_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "published",       default: false
+    t.boolean  "published",                   default: false
     t.datetime "publish_date"
-    t.string   "author"
+    t.string   "author",          limit: 255
   end
 
   add_index "catalogs", ["organization_id"], name: "index_catalogs_on_organization_id", using: :btree
@@ -64,18 +87,18 @@ ActiveRecord::Schema.define(version: 20160510041806) do
     t.text     "description"
     t.text     "keyword"
     t.datetime "modified"
-    t.string   "mbox"
-    t.string   "temporal"
-    t.string   "spatial"
+    t.string   "mbox",                limit: 255
+    t.string   "temporal",            limit: 255
+    t.string   "spatial",             limit: 255
     t.text     "landing_page"
-    t.string   "accrual_periodicity"
+    t.string   "accrual_periodicity", limit: 255
     t.integer  "catalog_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "publish_date"
-    t.string   "contact_position"
-    t.boolean  "public_access",       default: true
-    t.boolean  "editable",            default: true
+    t.string   "contact_position",    limit: 255
+    t.boolean  "public_access",                   default: true
+    t.boolean  "editable",                        default: true
     t.datetime "issued"
     t.string   "contact_name"
   end
@@ -95,15 +118,15 @@ ActiveRecord::Schema.define(version: 20160510041806) do
     t.text     "title"
     t.text     "description"
     t.text     "download_url"
-    t.string   "media_type"
+    t.string   "media_type",   limit: 255
     t.integer  "byte_size"
-    t.string   "temporal"
-    t.string   "spatial"
+    t.string   "temporal",     limit: 255
+    t.string   "spatial",      limit: 255
     t.integer  "dataset_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "modified"
-    t.string   "state"
+    t.string   "state",        limit: 255
     t.datetime "issued"
     t.datetime "publish_date"
     t.string   "format"
@@ -115,7 +138,7 @@ ActiveRecord::Schema.define(version: 20160510041806) do
     t.integer  "organization_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "authorization_file"
+    t.string   "authorization_file", limit: 255
     t.string   "designation_file"
   end
 
@@ -140,15 +163,6 @@ ActiveRecord::Schema.define(version: 20160510041806) do
 
   add_index "memo_files", ["organization_id"], name: "index_memo_files_on_organization_id", using: :btree
 
-  create_table "opening_plan_logs", force: :cascade do |t|
-    t.integer  "organization_id"
-    t.json     "opening_plan"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-  end
-
-  add_index "opening_plan_logs", ["organization_id"], name: "index_opening_plan_logs_on_organization_id", using: :btree
-
   create_table "organization_sectors", force: :cascade do |t|
     t.integer  "sector_id"
     t.integer  "organization_id"
@@ -160,12 +174,12 @@ ActiveRecord::Schema.define(version: 20160510041806) do
   add_index "organization_sectors", ["sector_id"], name: "index_organization_sectors_on_sector_id", using: :btree
 
   create_table "organizations", force: :cascade do |t|
-    t.string   "title"
+    t.string   "title",        limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "slug"
+    t.string   "slug",         limit: 255
     t.text     "description"
-    t.string   "logo_url"
+    t.string   "logo_url",     limit: 255
     t.integer  "gov_type"
     t.text     "landing_page"
   end
@@ -174,9 +188,9 @@ ActiveRecord::Schema.define(version: 20160510041806) do
   add_index "organizations", ["slug"], name: "index_organizations_on_slug", unique: true, using: :btree
 
   create_table "roles", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",          limit: 255
     t.integer  "resource_id"
-    t.string   "resource_type"
+    t.string   "resource_type", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -185,26 +199,26 @@ ActiveRecord::Schema.define(version: 20160510041806) do
   add_index "roles", ["name"], name: "index_roles_on_name", using: :btree
 
   create_table "sectors", force: :cascade do |t|
-    t.string   "title"
+    t.string   "title",      limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "slug"
+    t.string   "slug",       limit: 255
   end
 
   add_index "sectors", ["slug"], name: "index_sectors_on_slug", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "name",                   default: "", null: false
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+    t.string   "name",                   limit: 255, default: "", null: false
+    t.string   "email",                  limit: 255, default: "", null: false
+    t.string   "encrypted_password",     limit: 255, default: "", null: false
+    t.string   "reset_password_token",   limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",                      default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
+    t.string   "current_sign_in_ip",     limit: 255
+    t.string   "last_sign_in_ip",        limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "organization_id"
@@ -223,5 +237,4 @@ ActiveRecord::Schema.define(version: 20160510041806) do
 
   add_foreign_key "designation_files", "organizations"
   add_foreign_key "memo_files", "organizations"
-  add_foreign_key "opening_plan_logs", "organizations"
 end

--- a/spec/factories/catalog_versions.rb
+++ b/spec/factories/catalog_versions.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :catalog_version do
+    version foo: 'bar'
+    catalog
+  end
+end

--- a/spec/models/catalog_version_spec.rb
+++ b/spec/models/catalog_version_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe CatalogVersion, type: :model do
+  context 'validations' do
+    let(:catalog_version) { create(:catalog_version) }
+
+    it 'should be valid ' do
+      expect(catalog_version).to be_valid
+    end
+
+    it 'should not be valid without a version' do
+      catalog_version.version = nil
+      expect(catalog_version).not_to be_valid
+    end
+
+    it 'should not be valid without a catalog' do
+      catalog_version.catalog = nil
+      expect(catalog_version).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
### Changelog
* Se agrega la gema `audited-activerecord` para auditar las versiones de los modelos `Distribution` y `Dataset`.
* Se crea el modelo `CatalogVersion` que guarda el historico del catalogo.

### How to test

* Agregar conjuntos de datos en el Plan de Apertura.
* Editar conjuntos de datos y recursos existentes.
* Buscar las revisiones dentro del modelo `CatalogVersion`.
* Ver [audited](https://github.com/collectiveidea/audited#usage).

Closes #822 