### PR TITLE
Gov type

### DIFF
--- a/app/serializers/dataset_serializer.rb
+++ b/app/serializers/dataset_serializer.rb
@@ -14,6 +14,7 @@ class DatasetSerializer < ActiveModel::Serializer
     data[:keyword] = object.keywords.split(',').map(&:squish)
     data[:landingPage] = object.landing_page
     data[:accrualPeriodicity] = object.accrual_periodicity
+    data[:govType] = object.catalog.organization.gov_type
     data
   end
 

--- a/spec/requests/data_catalog_management_spec.rb
+++ b/spec/requests/data_catalog_management_spec.rb
@@ -41,7 +41,7 @@ feature 'data catalog management' do
     distribution.update_column(:state, 'published')
 
     dcat_keys = %w(title description homepage issued modified language license dataset)
-    dcat_dataset_keys = %w(identifier title description keyword modified contactPoint spatial landingPage language publisher distribution accrualPeriodicity)
+    dcat_dataset_keys = %w(identifier title description keyword modified contactPoint spatial landingPage language publisher distribution accrualPeriodicity govType)
     dcat_distribution_keys = %w(title description license downloadURL mediaType byteSize temporal spatial)
 
     get "/#{organization.slug}/catalogo.json"


### PR DESCRIPTION
###  Changelog
* Se agrega el metadato `govType` en la API del catálogo.

### How to test
1. Usando una organización con un `gov_type` asignado, verificar la API de su catálogo.

Closes #1006 