### PR TITLE
Splits the dataset temporal field into init_date and term_date

### DIFF
--- a/app/views/datasets/edit.html.haml
+++ b/app/views/datasets/edit.html.haml
@@ -31,21 +31,28 @@
             = f.label :mbox, 'Correo del responsable'
             = f.email_field :mbox, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.email_field')}"
       .row
+        = f.hidden_field(:temporal)
+        .col-xs-6
+          .form-group.required
+            = f.label :temporal, 'Inicio del período de tiempo cubierto', class: 'control-label'
+            %input#init-date.dcat-temporal.datepicker.form-control.auto_submit_item{ type: "text", placeholder: "Inicio", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.temporal.init')}", 'data-placement': 'bottom' }
+        .col-xs-6
+          .form-group.required
+            = f.label :temporal, 'Fin del período de tiempo cubierto', class: 'control-label'
+            %input#term-date.dcat-temporal.datepicker.form-control.auto_submit_items{ type: "text", placeholder: "Fin", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.temporal.term')}", 'data-placement': 'bottom' }
+      .row
         .col-xs-6
           .form-group.required
             = f.label :spatial
             = f.text_field :spatial, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.spatial')}"
         .col-xs-6
           .form-group.required
-            = f.label :temporal
-            = f.text_field :temporal, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.temporal')}"
+            = f.label :dataset_sectors, 'Categoría en datos.gob.mx'
+            = f.fields_for :dataset_sector do |sector_form|
+              = sector_form.select :sector_id, options_for_sectors_select, { include_blank: true }, { class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.sector')}" }
       .form-group.required
         = f.label :landing_page, 'URL para consultar diccionario de datos'
         = f.url_field :landing_page, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.landing_page')}"
-      .form-group.required
-        = f.label :dataset_sectors, 'Categoría en datos.gob.mx'
-        = f.fields_for :dataset_sector do |sector_form|
-          = sector_form.select :sector_id, options_for_sectors_select, { include_blank: true }, { class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.sector')}" }
       .form-group.required
         = f.label :keyword, 'Palabras clave (separadas por coma)'
         = f.text_area :keyword, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.keyword')}"
@@ -89,7 +96,29 @@
     %br
 
 :javascript
+  function onDistributionTemporalChange() {
+    var initDate, termDate, dcatTemporal;
+
+    initDate = $('#init-date').val();
+    termDate = $('#term-date').val();
+
+    dcatTemporal = initDate + "/" + termDate;
+    $('#dataset_temporal').val(dcatTemporal);
+  }
+
   $(function() {
+    (function () {
+      var initDate, termDate, dcatTemporal;
+
+      dcatTemporal = $('#dataset_temporal').val().split('/');
+      initDate = dcatTemporal[0];
+      termDate = dcatTemporal[1];
+
+      $('#init-date').val(initDate);
+      $('#term-date').val(termDate);
+    })();
+
+    $('.dcat-temporal').change(onDistributionTemporalChange);
     $('.auto_submit_item').change(function() {
       $('form').submit();
       toastr.success("#{t('flash.notice.dataset.update')}");

--- a/config/locales/tooltips/forms/dataset.yml
+++ b/config/locales/tooltips/forms/dataset.yml
@@ -12,7 +12,9 @@ es:
       publish_date: Fecha estimada de publicación del Conjunto de datos en el sitio de datos.gob.mx.
       email_field: Correo electrónico de contacto para atender dudas y comentarios sobre el conjunto de datos.
       spatial: Cobertura espacial del conjunto de datos. Algunos ejemplos son, "Baja California”, 002, "estatal” ó especificar un rango de coordenadas como "32.71,-112.32 27.99, -118.45”.
-      temporal: El período temporal que abarca el conjunto de datos. Algunos ejemplos son, "2013”, "2010/2012”, "2014-01/2014-04".
+      temporal:
+        init: Inicio del período temporal que abarca el conjunto de datos. Algunos ejemplos son, "2013”, "2014-01", etc.
+        term: Fin del período temporal que abarca el conjunto de datos. Algunos ejemplos son, "2014”, "2014-04", etc.
       landing_page: Dirección electrónica del diccionario de datos del Conjunto. Por ejemplo, "http://bit.ly/1t5IFsb".
       sector: Sector al que pertenece el Conjunto de Datos según el tema que trata.
       keyword: Lista de términos clave separados por coma, que facilitarán al usuario la búsqueda del conjunto de datos. Es importante considerar el uso de términos no técnicos; por ejemplo, "salud", "medicinas", "compras", "agricultura", etc.

--- a/spec/features/catalog/dataset_metadata_spec.rb
+++ b/spec/features/catalog/dataset_metadata_spec.rb
@@ -22,7 +22,8 @@ feature 'Catalog dataset metadata' do
     expect(page).to have_field('dataset_contact_position', with: dataset_attributes[:contact_position])
     expect(page).to have_field('dataset_mbox', with: dataset_attributes[:mbox])
     expect(page).to have_field('dataset_spatial', with: dataset_attributes[:spatial])
-    expect(page).to have_field('dataset_temporal', with: dataset_attributes[:temporal])
+    expect(page).to have_field('init-date', with: dataset_attributes[:temporal].split('/')[0])
+    expect(page).to have_field('term-date', with: dataset_attributes[:temporal].split('/')[1])
     expect(page).to have_field('dataset_landing_page', with: dataset_attributes[:landing_page])
     expect(page).to have_field('dataset_keyword', with: dataset_attributes[:keyword])
   end
@@ -31,7 +32,8 @@ feature 'Catalog dataset metadata' do
     fill_in('dataset_contact_position', with: dataset_attributes[:contact_position])
     fill_in('dataset_mbox', with: dataset_attributes[:mbox])
     fill_in('dataset_spatial', with: dataset_attributes[:spatial])
-    fill_in('dataset_temporal', with: dataset_attributes[:temporal])
+    fill_in('init-date', with: dataset_attributes[:temporal].split('/')[0])
+    fill_in('term-date', with: dataset_attributes[:temporal].split('/')[1])
     fill_in('dataset_landing_page', with: dataset_attributes[:landing_page])
     fill_in('dataset_keyword', with: dataset_attributes[:keyword])
     page.find('form').click # trigger the autosubmit by clicking anywhere


### PR DESCRIPTION
### Changelog
1. En el Catálogo, el campo `temporal` se documenta con una fecha de inicio y termino.

### How to Test
1. Documentar un conjunto en el catálogo.

Closes #1003 

<img width="1551" alt="captura de pantalla 2016-06-17 a las 9 41 32 a m" src="https://cloud.githubusercontent.com/assets/764518/16154279/b72ac4be-346f-11e6-9407-9aaaae852d5c.png">