### PR TITLE
Remove catalog autosubmit

### DIFF
--- a/app/controllers/concerns/dataset_actions.rb
+++ b/app/controllers/concerns/dataset_actions.rb
@@ -7,23 +7,24 @@ module DatasetActions
 
   def create
     @dataset = current_organization.catalog.datasets.create(dataset_params)
-    create_customization if create_customization.present?
+    create_customization if self.class.private_method_defined? :create_customization
   end
 
   def edit
     @dataset = Dataset.find(params['id'])
+    edit_customization if self.class.private_method_defined? :edit_customization
   end
 
   def update
     @dataset = Dataset.find(params['id'])
     @dataset.update(dataset_params)
-    update_customization if update_customization.present?
+    update_customization if self.class.private_method_defined? :update_customization
   end
 
   def destroy
     @dataset = Dataset.find(params['id'])
     @dataset.destroy
-    destroy_customization if destroy_customization.present?
+    destroy_customization if self.class.private_method_defined? :destroy_customization
   end
 
   private

--- a/app/controllers/concerns/distribution_actions.rb
+++ b/app/controllers/concerns/distribution_actions.rb
@@ -9,7 +9,7 @@ module DistributionActions
   def create
     @dataset = Dataset.find(params['dataset_id'])
     @distribution = @dataset.distributions.create(distribution_params)
-    create_customization if create_customization.present?
+    create_customization if self.class.private_method_defined? :create_customization
   end
 
   def edit
@@ -19,12 +19,12 @@ module DistributionActions
   def update
     @distribution = Distribution.find(params['id'])
     @distribution.update(distribution_params)
-    update_customization if update_customization.present?
+    update_customization if self.class.private_method_defined? :update_customization
   end
 
   def destroy
     @distribution = Distribution.find(params['id'])
     @distribution.destroy
-    destroy_customization if destroy_customization.present?
+    destroy_customization if self.class.private_method_defined? :destroy_customization
   end
 end

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -1,23 +1,21 @@
 class DatasetsController < ApplicationController
+  include DatasetActions
   before_action :authenticate_user!
 
   def index
     @catalog = current_organization.catalog
   end
 
-  def edit
-    @dataset = Dataset.find(params['id'])
+  private
+
+  def edit_customization
     @dataset.dataset_sector || @dataset.build_dataset_sector
   end
 
-  def update
-    @dataset = Dataset.find(params['id'])
-    @dataset.update(dataset_params)
-    render nothing: true
+  def update_customization
+    redirect_to organization_catalogs_path(current_organization)
     return
   end
-
-  private
 
   def dataset_params
     params.require(:dataset).permit(

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -1,20 +1,25 @@
 class DistributionsController < ApplicationController
+  include DistributionActions
   before_action :authenticate_user!
 
-  def edit
-    @distribution = Distribution.find(params['id'])
-  end
+  private
 
-  def update
-    @distribution = Distribution.find(params['id'])
-    @distribution.update(distribution_params)
+  def update_customization
     redirect_to edit_dataset_path(@distribution.dataset)
     return
   end
 
-  private
-
   def distribution_params
-    params.require(:distribution).permit(:title, :description, :publish_date, :download_url, :modified, :temporal, :byte_size)
+    params.require(:distribution).permit(
+      :title,
+      :description,
+      :publish_date,
+      :download_url,
+      :modified,
+      :temporal,
+      :byte_size,
+      :media_type,
+      :format
+    )
   end
 end

--- a/app/views/datasets/edit.html.haml
+++ b/app/views/datasets/edit.html.haml
@@ -2,7 +2,7 @@
 .row
   .col-md-9
     %h3 Documentar un Conjunto de Datos
-    = form_for(@dataset, remote: true) do |f|
+    = form_for(@dataset) do |f|
       .form-group.required
         = f.label :title, class: 'control-label'
         = f.text_field :title, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.title')}"
@@ -59,6 +59,9 @@
       .form-group
         = f.label :comments, 'Observaciones'
         = f.text_area :comments, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.comments')}"
+      .form-group
+        = f.button 'Guardar', type: 'submit', class: 'btn btn-primary btn-lg'
+        = link_to 'Cancelar', organization_catalogs_path(current_organization), class: 'btn btn-alt btn-lg'
   .col-md-3
     %p.margin-top
       Los metadatos ayudan a que los usuarios entiendan las características de la información que

--- a/app/views/datasets/edit.html.haml
+++ b/app/views/datasets/edit.html.haml
@@ -5,60 +5,60 @@
     = form_for(@dataset, remote: true) do |f|
       .form-group.required
         = f.label :title, class: 'control-label'
-        = f.text_field :title, required: true, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.title')}"
+        = f.text_field :title, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.title')}"
       .form-group.required
         = f.label :description, class: 'control-label'
-        = f.text_area :description, required: true, class: 'form-control auto_submit_item autosize', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.description')}"
+        = f.text_area :description, required: true, class: 'form-control autosize', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.description')}"
       .row
         .col-xs-6
           .form-group.required
             = f.label :accrual_periodicity, class: 'control-label'
-            = f.select :accrual_periodicity, iso8601_repeating_interval_options_for_select(f.object.accrual_periodicity), {}, required: true, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.accrual_periodicity')}"
+            = f.select :accrual_periodicity, iso8601_repeating_interval_options_for_select(f.object.accrual_periodicity), {}, required: true, class: 'form-control ', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.accrual_periodicity')}"
         .col-xs-6
           .form-group.required
             = f.label :publish_date, class: 'control-label'
-            = f.text_field :publish_date, value: f.object.publish_date.strftime('%F'), class: 'datepicker auto_submit_item form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.publish_date')}"
+            = f.text_field :publish_date, value: f.object.publish_date.strftime('%F'), class: 'datepicker  form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.publish_date')}"
       .form-group
         = f.label :contact_name, class: 'control-label'
-        = f.text_field :contact_name, class: 'auto_submit_item form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.contact_name')}"
+        = f.text_field :contact_name, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.contact_name')}"
       .row
         .col-xs-6
           .form-group.required
             = f.label :contact_position, 'Cargo del responsable'
-            = f.text_field :contact_position, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.contact_position')}"
+            = f.text_field :contact_position, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.contact_position')}"
         .col-xs-6
           .form-group.required
             = f.label :mbox, 'Correo del responsable'
-            = f.email_field :mbox, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.email_field')}"
+            = f.email_field :mbox, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.email_field')}"
       .row
         = f.hidden_field(:temporal)
         .col-xs-6
           .form-group.required
             = f.label :temporal, 'Inicio del período de tiempo cubierto', class: 'control-label'
-            %input#init-date.dcat-temporal.datepicker.form-control.auto_submit_item{ type: "text", placeholder: "Inicio", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.temporal.init')}", 'data-placement': 'bottom' }
+            %input#init-date.dcat-temporal.datepicker.form-control{ type: "text", placeholder: "Inicio", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.temporal.init')}", 'data-placement': 'bottom' }
         .col-xs-6
           .form-group.required
             = f.label :temporal, 'Fin del período de tiempo cubierto', class: 'control-label'
-            %input#term-date.dcat-temporal.datepicker.form-control.auto_submit_items{ type: "text", placeholder: "Fin", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.temporal.term')}", 'data-placement': 'bottom' }
+            %input#term-date.dcat-temporal.datepicker.form-control{ type: "text", placeholder: "Fin", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.temporal.term')}", 'data-placement': 'bottom' }
       .row
         .col-xs-6
           .form-group.required
             = f.label :spatial
-            = f.text_field :spatial, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.spatial')}"
+            = f.text_field :spatial, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.spatial')}"
         .col-xs-6
           .form-group.required
             = f.label :dataset_sectors, 'Categoría en datos.gob.mx'
             = f.fields_for :dataset_sector do |sector_form|
-              = sector_form.select :sector_id, options_for_sectors_select, { include_blank: true }, { class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.sector')}" }
+              = sector_form.select :sector_id, options_for_sectors_select, { include_blank: true }, { class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.sector')}" }
       .form-group.required
         = f.label :landing_page, 'URL para consultar diccionario de datos'
-        = f.url_field :landing_page, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.landing_page')}"
+        = f.url_field :landing_page, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.landing_page')}"
       .form-group.required
         = f.label :keyword, 'Palabras clave (separadas por coma)'
-        = f.text_area :keyword, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.keyword')}"
+        = f.text_area :keyword, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.keyword')}"
       .form-group
         = f.label :comments, 'Observaciones'
-        = f.text_area :comments, class: 'form-control auto_submit_item', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.comments')}"
+        = f.text_area :comments, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.comments')}"
   .col-md-3
     %p.margin-top
       Los metadatos ayudan a que los usuarios entiendan las características de la información que
@@ -122,9 +122,5 @@
     })();
 
     $('.dcat-temporal').change(onDistributionTemporalChange);
-    $('.auto_submit_item').change(function() {
-      $('form').submit();
-      toastr.success("#{t('flash.notice.dataset.update')}");
-    });
     $('tr:contains("Listo para publicar")').addClass('success');
   });

--- a/app/views/distributions/edit.html.haml
+++ b/app/views/distributions/edit.html.haml
@@ -13,6 +13,16 @@
         = f.label :download_url, 'URL para descargar'
         = f.url_field :download_url, class: 'form-control', required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.download_url')}"
       .row
+        .col-xs-6
+          .form-group.required
+            = f.label :media_type, class: 'control-label'
+            = select_tag :media_type_select, options_for_media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type_select')}"
+            = f.hidden_field :media_type, value: f.object.media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type')}"
+        .col-xs-6
+          .form-group
+            = f.label :format, class: 'control-label'
+            = f.text_field :format, value: f.object.format, required: true, class: 'form-control'
+      .row
         = f.hidden_field(:temporal)
         .col-xs-6
           .form-group.required
@@ -34,10 +44,6 @@
     .col-md-3
       %p.margin-top
         Los metadatos ayudan a que los usuarios entiendan las características de la información que se está publicando. La documentación es importante porque afecta la calidad de los datos y el potencial de su uso e impacto.
-      %p
-        <strong>Nombre del recurso:</strong> #{@distribution.title}
-      %p
-        <strong>Fecha compromiso de publicación:</strong> #{@distribution.dataset.publish_date.strftime('%F')}
   .row
     .col-xs-9.margin-top-20
       = f.button 'Guardar', type: 'submit', class: 'btn btn-primary btn-lg'

--- a/app/views/inventories/distributions/edit.html.haml
+++ b/app/views/inventories/distributions/edit.html.haml
@@ -14,7 +14,7 @@
       - unless @distribution.issued?
         .form-group.required
           = f.label :publish_date, class: 'control-label'
-          = f.text_field :publish_date, value: f.object.publish_date&.strftime('%F'), required: true, class: 'datepicker auto_submit_item form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
+          = f.text_field :publish_date, value: f.object.publish_date&.strftime('%F'), required: true, class: 'datepicker form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
       .form-group.required
         = f.label :media_type, class: 'control-label'
         = select_tag :media_type_select, options_for_media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type_select')}"

--- a/app/views/inventories/distributions/new.html.haml
+++ b/app/views/inventories/distributions/new.html.haml
@@ -13,7 +13,7 @@
         = f.text_area :description, required: true, class: 'autosize form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.description')}"
       .form-group.required
         = f.label :publish_date, class: 'control-label'
-        = f.text_field :publish_date, value: @dataset.publish_date&.strftime('%F'), required: true, class: 'datepicker auto_submit_item form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
+        = f.text_field :publish_date, value: @dataset.publish_date&.strftime('%F'), required: true, class: 'datepicker form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}"
       .form-group.required
         = f.label :media_type, class: 'control-label'
         = select_tag :media_type_select, options_for_media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type_select')}"

--- a/spec/features/catalog/dataset_metadata_spec.rb
+++ b/spec/features/catalog/dataset_metadata_spec.rb
@@ -16,8 +16,11 @@ feature 'Catalog dataset metadata' do
 
     dataset_attributes = attributes_for(:dataset)
     fill_catalog_dataset_metadata(dataset_attributes)
+    click_on 'Guardar'
 
-    visit(current_path)
+    within set_row do
+      click_on('Documentar')
+    end
 
     expect(page).to have_field('dataset_contact_position', with: dataset_attributes[:contact_position])
     expect(page).to have_field('dataset_mbox', with: dataset_attributes[:mbox])
@@ -38,6 +41,5 @@ feature 'Catalog dataset metadata' do
     fill_in('dataset_landing_page', with: dataset_attributes[:landing_page])
     fill_in('dataset_keyword', with: dataset_attributes[:keyword])
     fill_in('dataset_comments', with: dataset_attributes[:comments])
-    page.find('form').click # trigger the autosubmit by clicking anywhere
   end
 end


### PR DESCRIPTION
### Changelog
1. Se quita el autosubmit del catálogo de datos.
1. Se agregan al formulario de un recurso del inventario, los campos: `media_type` y `format`.

### How to test
1. Documentar un conjunto de datos en el catálogo.
1. Documentar un recurso de daros en el catálogo.

Closes #992 
Closes #991 