### PR TITLE
Download URL validations

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -5,7 +5,11 @@ class DistributionsController < ApplicationController
   private
 
   def update_customization
-    redirect_to edit_dataset_path(@distribution.dataset)
+    if @distribution.valid?
+      redirect_to edit_dataset_path(@distribution.dataset)
+      return
+    end
+    render :edit
     return
   end
 

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -5,7 +5,7 @@ class Distribution < ActiveRecord::Base
   audited associated_with: :dataset
 
   validate :mandatory_fields
-  validates_uniqueness_of :title
+  validates_uniqueness_of :title, :download_url
 
   has_one :catalog, through: :dataset
 

--- a/app/views/distributions/edit.html.haml
+++ b/app/views/distributions/edit.html.haml
@@ -3,6 +3,10 @@
   .row
     .col-md-9
       %h3 Documentar un Recurso de Datos
+      - if @distribution.errors.any?
+        = render partial: '/layouts/shared/errors', locals: { errors: @distribution.errors }
+  .row
+    .col-md-9
       .form-group.required
         = f.label :title, class: 'control-label'
         = f.text_field :title, required: true, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.title')}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -94,6 +94,8 @@ es:
           attributes:
             title:
               taken: 'Existe otro recurso con el mismo nombre, verifica tu plan de apertura.'
+            download_url:
+              taken: 'Existe otro recurso con la misma URL de descarga.'
     attributes:
       user:
         name: "Nombre"

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -44,6 +44,15 @@ describe Distribution do
     it_behaves_like 'a non compliant distribution'
   end
 
+  context 'with a duplicated download_url' do
+    let(:distribution) { create(:distribution, download_url: Faker::Internet.url ) }
+
+    it 'should not be valid' do
+      invalid_distribution = build(:distribution, download_url: distribution.download_url )
+      expect(invalid_distribution).not_to be_valid
+    end
+  end
+
   context 'after save' do
     let(:dataset) { create(:dataset, modified: Date.yesterday) }
     let(:distribution) { build(:distribution, dataset: dataset, modified: Date.today) }


### PR DESCRIPTION
### Changelog
1. Valida que la URL de descarga de un recurso sea unica.

### How to test
1. Documenta dos recursos con la misma url de descarga.

<img width="1551" alt="captura de pantalla 2016-07-05 a las 6 54 04 p m" src="https://cloud.githubusercontent.com/assets/764518/16603529/5431c034-42e2-11e6-908c-1249a02f3dc2.png">

Closes #827 