### PR TITLE
FTP Passive Mode

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -11,5 +11,6 @@ CarrierWave.configure do |config|
     config.ftp_passwd = ENV['FTP_PASSWD']
     config.ftp_folder = ENV['FTP_FOLDER']
     config.ftp_url = ENV['FTP_URL']
+    config.ftp_passive = true
   end
 end

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,1 +1,1 @@
-Rack::Timeout.service_timeout = 12 if Rails.env.production?
+Rack::Timeout.service_timeout = ENV['RACK_TIMEOUT'] || 10 if Rails.env.production?


### PR DESCRIPTION
### Changelog
1. Se configura el timeout de Rack en una variable de entorno `RACK_TIMEOUT`.
1. Se configura el FTP de Carrierwave para usar el modo pasivo.

### How to test
1. En la sección de documentos, agregar un archivo de designación o minuta.

Closes #1023 