### PR TITLE
Warning al publicar datos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development, :test do
   gem 'letter_opener'
   gem 'thin'
   gem 'timecop'
+  gem 'pry'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     charlock_holmes (0.7.3)
     childprocess (0.5.8)
       ffi (~> 1.0, >= 1.0.11)
+    coderay (1.1.1)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -181,6 +182,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.99)
     mini_portile2 (2.0.0)
     minitest (5.8.3)
@@ -193,6 +195,10 @@ GEM
       mini_portile2 (~> 2.0.0.rc2)
     orm_adapter (0.5.0)
     pg (0.18.4)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.6.4)
     rack-cors (0.4.0)
     rack-pjax (0.8.0)
@@ -301,6 +307,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     spreadsheet (1.1.0)
       ruby-ole (>= 1.0)
     spring (1.6.1)
@@ -404,6 +411,7 @@ DEPENDENCIES
   nested_form
   newrelic_rpm
   pg
+  pry
   rack-cors
   rack-pjax
   rails (= 4.2.5)
@@ -432,5 +440,8 @@ DEPENDENCIES
   validate_url
   will_paginate (~> 3.0)
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/assets/javascripts/components/agreement.js
+++ b/app/assets/javascripts/components/agreement.js
@@ -1,7 +1,9 @@
 var termsConfirmed = function() {
   if( $('#agreement-publish').is(':checked') && $('#agreement-validated').is(':checked') ){
     $('#publish').removeClass('disabled');
+    $('#adela-message').toggleClass('hidden');
   } else {
     $('#publish').addClass('disabled');
+    $('#adela-message').addClass('hidden');
   }
 };

--- a/app/controllers/catalogs_controller.rb
+++ b/app/controllers/catalogs_controller.rb
@@ -37,7 +37,7 @@ class CatalogsController < ApplicationController
 
   def notify_administrator
     administrator = @catalog.organization.administrator
-    CatalogMailer.publish_email(@catalog.id, administrator.user.id).deliver_now if administrator
+    CatalogMailer.publish_email(@catalog.id, administrator&.user&.id).deliver_now
   end
 
   def publish_distributions

--- a/app/mailers/catalog_mailer.rb
+++ b/app/mailers/catalog_mailer.rb
@@ -5,8 +5,8 @@ class CatalogMailer < ActionMailer::Base
 
   def publish_email(catalog_id, user_id)
     @catalog = Catalog.find(catalog_id)
-    @user = User.find(user_id)
-    mail(to: @user.email, from: MAILER_FROM, subject: publish_email_subject(@catalog))
+    @user_email = User.find_by(id: user_id)&.email || BCC_EMAIL
+    mail(to: @user_email, from: MAILER_FROM, bcc: BCC_EMAIL, subject: publish_email_subject(@catalog))
   end
 
   private

--- a/app/views/catalog_mailer/publish_email.html.haml
+++ b/app/views/catalog_mailer/publish_email.html.haml
@@ -22,7 +22,7 @@
           %p= "Frecuencia de actualización: #{accrual_periodicity_translate(dataset.accrual_periodicity)}"
           %p= "Período de tiempo que cubre: #{dataset.temporal}"
           %p= "Fecha de última modificación: #{dataset.modified}"
-          %p= "Sector: #{dataset.sector.title}"
+          %p= "Sector: #{dataset.sector&.title}"
           %p= "Palabras clave: #{dataset.keyword}"
           %p= "Dirección web de diccionario: #{dataset.landing_page}"
 

--- a/app/views/catalogs/check.html.haml
+++ b/app/views/catalogs/check.html.haml
@@ -107,7 +107,7 @@
           %input#agreement-validated{ type: 'checkbox', 'onClick'=>'termsConfirmed()' }
             = t('agreement.validated')
 
-      .section
+      .section.hidden#adela-message
         .alert.alert-warning{role: 'alert'}
           Adela está cambiando para brindarte un mejor servicio. Durante este período la publicación de tus
           datos podrá tomar hasta 24hrs. Para cualquier duda o soporte, favor de escribir a

--- a/app/views/catalogs/check.html.haml
+++ b/app/views/catalogs/check.html.haml
@@ -107,5 +107,11 @@
           %input#agreement-validated{ type: 'checkbox', 'onClick'=>'termsConfirmed()' }
             = t('agreement.validated')
 
+      .section
+        .alert.alert-warning{role: 'alert'}
+          Adela está cambiando para brindarte un mejor servicio. Durante este período la publicación de tus
+          datos podrá tomar hasta 24hrs. Para cualquier duda o soporte, favor de escribir a
+          = mail_to 'escuadron@datos.mx', nil, class: 'alert-link'
+
       = f.button t('action.publish'), type: 'submit', class: 'btn btn-primary disabled', id: 'publish'
       = link_to 'Volver al catálogo', catalog_datasets_path(current_organization.catalog), class: 'btn btn-default'

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -1,4 +1,5 @@
 MAILER_FROM = ENV['MAILER_FROM'] || 'no-reply@adela.com'
+BCC_EMAIL = ENV['BCC_EMAIL'] || 'carlos.maya@datos.mx'
 
 if Rails.env.production?
   ActionMailer::Base.smtp_settings = {

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -5,10 +5,6 @@ preload_app true
 @worker = nil
 
 before_fork do |server, worker|
-
-  @worker ||= spawn("bundle exec rake jobs:work")
-  @sidekiq_pid ||= spawn("bundle exec sidekiq -c 2")
-
   Signal.trap 'TERM' do
     puts 'Unicorn master intercepting TERM and sending myself QUIT instead'
     Process.kill 'QUIT', Process.pid
@@ -16,7 +12,7 @@ before_fork do |server, worker|
 
   defined?(ActiveRecord::Base) and
     ActiveRecord::Base.connection.disconnect!
-end 
+end
 
 after_fork do |server, worker|
 


### PR DESCRIPTION
### Changelog

* Se agrega un aviso para notificar a los funcionarios que sus datos pueden tardar hasta 24 horas en verse publicados.
* Se envía un correo con bcc a un usuario para hacer la sincronización  de datos. Se configura el correo con la variable de entorno `BCC_EMAIL`.
* Se agrega la gema [pry](https://github.com/pry/pry) en el grupo de `development`.
* En el archivo de configuración de unicorn, se eliminan las llamadas a `sidekiq` y `rake jobs:work`.

### How to test

1. En la pantalla de "Validar y Publicar", al momento de verificar los últimos checkboxes se mostrara el mensaje de alerta.

<img width="1552" alt="captura de pantalla 2016-09-02 a las 10 46 49 a m" src="https://cloud.githubusercontent.com/assets/764518/18210148/c41be2f6-70fc-11e6-96aa-835f823dac39.png">

Closes #1048 
Closes #1049
