### PR TITLE
Configures the rails relative url root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ruby:2.3.0-alpine
 
 ENV \
   RAILS_ENV="production" \
+  RAILS_RELATIVE_URL_ROOT="/adela" \
   BUILD_PACKAGES="build-base curl-dev" \
   RAILS_PACKAGES="icu-dev zlib-dev libxml2-dev libxslt-dev tzdata postgresql-dev nodejs"
 

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,8 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
-run Rails.application
+
+relative_url_root = Adela::Application.config.relative_url_root || '/'
+map relative_url_root do
+  run Rails.application
+end


### PR DESCRIPTION
### Changelog

Se configura Adela para poder correr bajo el directorio `/adela`.

### How to test

1. Levantar Adela en [Docker](https://github.com/mxabierto/adela/wiki/Docker-CLI).

Closes #1015 

<img width="1552" alt="captura de pantalla 2016-09-28 a la s 02 03 39" src="https://cloud.githubusercontent.com/assets/764518/18903711/424e8106-8520-11e6-8073-a40f25951c7e.png">
