### PR TITLE
GobTool-Sprin45

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -43,8 +43,7 @@ class Distribution < ActiveRecord::Base
       return unless dataset
       dataset.update_attribute(:modified, modified) if dataset.modified < modified
     end
-
     def validate_modified_not_higher_today
-      errors.add(:modified, "El valor del campo \"Fecha de última modificación de datos\" debe ser menor a la fecha actual.") if self.modified > Time.now
+      errors.add(:modified, 'El valor del campo \"Fecha de última modificación de datos\" debe ser menor a la fecha actual.') if self.modified > Time.now
     end
 end

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -8,6 +8,8 @@ class Distribution < ActiveRecord::Base
   validates_uniqueness_of :title
   validates_uniqueness_of :download_url, allow_nil: true
 
+  validate :validate_modified_not_higher_today
+
   has_one :catalog, through: :dataset
   has_one :organization, through: :dataset
 
@@ -40,5 +42,9 @@ class Distribution < ActiveRecord::Base
     def update_dataset_metadata
       return unless dataset
       dataset.update_attribute(:modified, modified) if dataset.modified < modified
+    end
+
+    def validate_modified_not_higher_today
+      errors.add(:modified, "El valor del campo \"Fecha de última modificación de datos\" debe ser menor a la fecha actual.") if self.modified > Time.now
     end
 end

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -19,8 +19,8 @@ describe Distribution do
     end
 
     it 'should not be valid with higher modified that today' do
-      new_distribution = build(:distribution, modified: Date.today.next_day(1) )
-      expect( new_distribution).not_to be_valid
+      new_distribution = build(:distribution, modified:Date.today.next_day(1))
+      expect(new_distribution).not_to be_valid
     end
   end
 

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -17,6 +17,11 @@ describe Distribution do
       new_distribution = build(:distribution, title: distribution.title)
       expect(new_distribution).not_to be_valid
     end
+
+    it 'should not be valid with higher modified that today' do
+      new_distribution = build(:distribution, modified: Date.today.next_day(1) )
+      expect( new_distribution).not_to be_valid
+    end
   end
 
   describe '#valid?(:ckan)' do


### PR DESCRIPTION
validación para el campo "modified" impide ingresar fechas posteriores a la actual.