### PR TITLE
Feature: Configuración tooltip de campos tipo fecha

### DIFF
--- a/app/views/datasets/edit.html.haml
+++ b/app/views/datasets/edit.html.haml
@@ -18,7 +18,7 @@
         .col-xs-6
           .form-group.required
             = f.label 'Fecha de publicación', class: 'control-label'
-            = f.text_field :publish_date, value: f.object.publish_date&.strftime('%F'), required: true, class: 'datepicker form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.publish_date')}"
+            = f.text_field :publish_date, 'data-placement':'right', 'data-container':'body', readonly:true, value: f.object.publish_date&.strftime('%F'), required: true, class: 'datepicker form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.publish_date')}"
       .form-group
         = f.label :contact_name, class: 'control-label'
         = f.text_field :contact_name, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.contact_name')}"
@@ -36,11 +36,11 @@
         .col-xs-6
           .form-group.required
             = f.label :temporal, 'Inicio del período de tiempo cubierto', class: 'control-label'
-            %input#init-date.dcat-temporal.datepicker.form-control{ type: "text", placeholder: "Inicio", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.temporal.init')}", 'data-placement': 'bottom' }
+            %input#init-date.dcat-temporal.datepicker.form-control{type: "text", placeholder: "Inicio", required: true, 'data-toggle': 'tooltip', 'data-container':'body', title: "#{t('tooltip.dataset.temporal.init')}", 'data-placement': 'right', readonly:true }
         .col-xs-6
           .form-group.required
             = f.label :temporal, 'Fin del período de tiempo cubierto', class: 'control-label'
-            %input#term-date.dcat-temporal.datepicker.form-control{ type: "text", placeholder: "Fin", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.temporal.term')}", 'data-placement': 'bottom' }
+            %input#term-date.dcat-temporal.datepicker.form-control{type: "text", placeholder: "Fin", required: true, 'data-toggle': 'tooltip', 'data-container':'body', title: "#{t('tooltip.dataset.temporal.term')}", 'data-placement': 'right', readonly:true }
       .row
         .col-xs-6
           .form-group.required

--- a/app/views/distributions/edit.html.haml
+++ b/app/views/distributions/edit.html.haml
@@ -20,7 +20,7 @@
         .col-xs-6
           .form-group.required
             = f.label :media_type, class: 'control-label'
-            = select_tag :media_type_select, options_for_media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type_select')}"
+            = select_tag :media_type_select, options_for_media_type, class: 'form-control', 'data-toggle': 'tooltip','data-placement':'top', title: "#{t('tooltip.distribution.media_type_select')}"
             = f.hidden_field :media_type, value: f.object.media_type, class: 'form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.media_type')}"
         .col-xs-6
           .form-group
@@ -31,16 +31,16 @@
         .col-xs-6
           .form-group.required
             = f.label :temporal, 'Inicio del período de tiempo cubierto', class: 'control-label'
-            %input#init-date.dcat-temporal.datepicker.form-control{ type: "text", placeholder: "Inicio", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.temporal.init')}" }
+            %input#init-date.dcat-temporal.datepicker.form-control{'data-placement':'right', 'data-container':'body', readonly: true, type: "text", placeholder: "Inicio", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.temporal.init')}" }
         .col-xs-6
           .form-group.required
             = f.label :temporal, 'Fin del período de tiempo cubierto', class: 'control-label'
-            %input#term-date.dcat-temporal.datepicker.form-control{ type: "text", placeholder: "Fin", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.temporal.term')}" }
+            %input#term-date.dcat-temporal.datepicker.form-control{ 'data-placement':'right', 'data-container':'body', readonly: true, type: "text", placeholder: "Fin", required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.temporal.term')}" }
       .row
         .col-xs-6
           .form-group.required
             = f.label :modified, 'Fecha de última modificación de datos',  class: 'control-label'
-            = f.text_field :modified, value: f.object.modified&.strftime('%F'), class: 'form-control input-icon datepicker', required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.modified')}", 'data-placement': 'bottom'
+            = f.text_field :modified, value: f.object.modified&.strftime('%F'), 'data-placement':'right', 'data-container':'body', class: 'form-control input-icon datepicker', readonly: true, required: true, 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.modified')}"
         .col-xs-6
           .form-group.required
             = f.label :byte_size, 'Tamaño en Bytes'


### PR DESCRIPTION
### Registro de cambios
1.- Configuración tooltip de bootstrap en los campos de tipo fecha para evitar que se interponga con el calendario.
2.- Se agrego propiedad readonly en fecha para forzar el uso del calendario y así evitar el ingreso de caracteres y formatos no permitidos.

### Como probar
1.- En el catálogo de datos, documentar conjunto y recurso de datos.