### PR TITLE
Chore: API ISO-8601

### DIFF
--- a/app/serializers/catalog_serializer.rb
+++ b/app/serializers/catalog_serializer.rb
@@ -1,16 +1,23 @@
 class CatalogSerializer < ActiveModel::Serializer
   has_many :datasets, root: :dataset, serializer: Catalog::DatasetSerializer
+  attributes :issued, :modified
 
   def attributes
     data ||= {}
     data[:title] = "Catálogo de datos abiertos de #{object.organization.title}"
     data[:description] = ''
     data[:homepage] = ''
-    data[:issued] = "#{object.created_at}"
-    data[:modified] = "#{object.publish_date}"
     data[:language] = 'es'
     data[:license] = 'http://datos.gob.mx/libreusomx/'
     data.merge super
+  end
+
+  def issued
+    object.created_at
+  end
+
+  def modified
+    object.publish_date
   end
 
   def datasets

--- a/config/initializers/iso8601_serializer.rb
+++ b/config/initializers/iso8601_serializer.rb
@@ -1,0 +1,7 @@
+module ActiveSupport
+  class TimeWithZone
+    def as_json(options = {})
+      iso8601
+    end
+  end
+end

--- a/spec/requests/data_catalog_management_spec.rb
+++ b/spec/requests/data_catalog_management_spec.rb
@@ -53,7 +53,7 @@ feature 'data catalog management' do
 
     get "/#{organization.slug}/catalogo.json"
     json_response = JSON.parse(response.body)
-    expect(json_response.keys).to eq(dcat_keys)
+    expect(json_response.keys.sort).to eq(dcat_keys.sort)
     expect(json_response['dataset'].last.keys.sort).to eq(dcat_dataset_keys.sort)
     expect(json_response['dataset'].last['distribution'].last.keys.sort).to eq(dcat_distribution_keys.sort)
   end


### PR DESCRIPTION
### Changelog
Monkey Patches the `ActiveSupport::TimeWithZone#as_json` method to show dates in the ISO-8601 format.

### How to Test
1. Fetch an organization catalog.

```
{
  "title": "Catálogo de datos abiertos de México Abierto",
  "description": "",
  "homepage": "",
  "language": "es",
  "license": "http://datos.gob.mx/libreusomx/",
  "issued": "2016-10-05T01:40:54Z",
  "modified": "2016-10-05T01:58:24Z",
  "dataset": [
    {
      "id": 3,
      "title": "chacos",
      "description": "fooo",
      "issued": "2016-10-05T01:58:24Z",
      "modified": null,
      "identifier": "chacos",
      "theme": "Finanzas y Contrataciones",
      "keyword": [
        "foo",
        "bar"
      ],
      "language": "es",
      "contactPoint": "http://adela.datos.gob.mx/api/v1/datasets/3/contact_point.vcf",
      "temporal": "2016-10-08/2016-10-31",
      "spatial": "mexico",
      "govType": null,
      "accrualPeriodicity": "R/P2M",
      "landingPage": "http://aliada.mx",
      "openessRating": 3,
      "comments": "niet",
      "quality": "http://datos.gob.mx/",
      "publisher": {
        "name": "sdfdsaAFDACAX",
        "position": "ksks",
        "mbox": "babasbot@gmail.com"
      },
      "public": true,
      "publishDate": "2016-10-18T00:00:00Z",
      "distribution": [
        {
          "id": 4,
          "title": "ksksks",
          "description": "ksksksks",
          "issued": "2016-10-05T01:58:24Z",
          "modified": "2016-10-01T00:00:00Z",
          "license": "http://datos.gob.mx/libreusomx/",
          "spatial": "mexico",
          "downloadURL": "http://wolf.net/dianna",
          "mediaType": "application/vnd.google-earth.kml+xml",
          "format": "kml",
          "byteSize": 1024,
          "temporal": "2016-09-06/2016-10-06",
          "tools": "foo bar",
          "publishDate": "2016-10-18T00:00:00Z"
        }
      ]
    }
  ]
}
```

Closes #1071 