### PR TITLE
Chore: Validates datepicker inputs with ISO-8601 date format

### DIFF
--- a/app/assets/javascripts/jquery/validate/messages.js
+++ b/app/assets/javascripts/jquery/validate/messages.js
@@ -1,4 +1,5 @@
 jQuery.extend(jQuery.validator.messages, {
     required: "Completa este campo",
-    url: "Ingresa una URL valida"
+    url: "Ingresa una URL valida",
+    dateISO: "Ingresa una fecha valida en formato ISO-8601"
 });

--- a/app/assets/javascripts/jquery/validate/ready.js
+++ b/app/assets/javascripts/jquery/validate/ready.js
@@ -1,3 +1,6 @@
 $(function() {
     $("form").validate();
+    $(".datepicker").rules("add", {
+        dateISO: true
+    });
 });


### PR DESCRIPTION
### Changelog

Validates that datepicker inputs containt the ISO-8601 date format.

### How to test

1. Edit any datepicker input with an invalid date.

<img width="301" alt="captura de pantalla 2016-10-11 a la s 21 07 03" src="https://cloud.githubusercontent.com/assets/764518/19295089/cab518de-8ff7-11e6-9063-8b5310c8df74.png">

Closes #1069 