### PR TITLE
Fixes a javascript error

### DIFF
--- a/app/assets/javascripts/jquery/validate/ready.js
+++ b/app/assets/javascripts/jquery/validate/ready.js
@@ -1,6 +1,10 @@
 $(function() {
+    var datepicker = $(".datepicker");
     $("form").validate();
-    $(".datepicker").rules("add", {
+
+    if (datepicker.length) {
+      datepicker.rules("add", {
         dateISO: true
-    });
+      });
+    }
 });


### PR DESCRIPTION
### Changelog
Javascript run time crashed when the selector `.datepicker` didn't find any element.

### How to Test
1. In the *"Catálogo"* or *"Plan de Apertura"*, try to collapse some dataset distributions.

Closes #1089 