### PR TITLE
chore: botón cancelar en la pantalla confirma eliminación de conjunto y recurso

### DIFF
--- a/app/views/inventories/datasets/confirm_destroy.html.haml
+++ b/app/views/inventories/datasets/confirm_destroy.html.haml
@@ -5,4 +5,4 @@
       %p
         Al borrar el conjunto: <strong class='highlight'>#{@dataset.title}</strong>, se perderán también los recursos asociados a éste.
       = link_to 'Eliminar Conjunto de Datos', inventories_dataset_path(@dataset), data: {}, method: :delete, class: 'btn btn-primary'
-      = link_to 'Cancelar', inventories_datasets_path, class: 'btn btn-default'
+      = link_to 'Cancelar', inventories_datasets_path, class: 'btn btn-primary'

--- a/app/views/inventories/distributions/confirm_destroy.html.haml
+++ b/app/views/inventories/distributions/confirm_destroy.html.haml
@@ -5,4 +5,4 @@
       %p
         ¿Estás seguro que deseas eliminar el recurso: <strong class='highlight'>#{@distribution.title}</strong>, que pertenece al conjunto: <strong class='highlight'>#{@distribution.dataset.title}</strong>?
       = link_to 'Eliminar Recurso', inventories_dataset_distribution_path(@distribution.dataset, @distribution), data: {}, method: :delete, class: 'btn btn-primary'
-      = link_to 'Cancelar', inventories_datasets_path, class: 'btn btn-default'
+      = link_to 'Cancelar', inventories_datasets_path, class: 'btn btn-primary'


### PR DESCRIPTION
### Cambios realizados

- Modificación al estilo de bootstrap del botón cancelar operación dentro de la pantalla "destroy_catalog"
- Modificación al estilo de bootstrap del botón cancelar operación dentro de la pantalla "destroy_distribution"

### ¿Cómo validar?

- En Plan de apertura eliminar conjunto
- En Plan de apertura eliminar recurso