### PR TITLE
Bug: Change title property to logo URL by slug

### DIFF
--- a/app/views/organizations/shared/_dashboard.html.erb
+++ b/app/views/organizations/shared/_dashboard.html.erb
@@ -316,7 +316,7 @@ $(".openModal").click(function(){
 });
 
 var orgCount = "<%= Organization.count %>";
-var strName = "<%= current_user.organization.title %>";
+var strName = "<%= current_user.organization.slug %>";
 var orgName = strName.toLowerCase();
 var pageSize = '&pageSize=20000';
 var issuedTotal = 0;


### PR DESCRIPTION
### Changelog

Change title property to logo URL by slug

### How to test

In sashboard the URL of the image that is displayed, must have the slug of the institution.
