### PR TITLE
fix:set default value for the variable CDN_URL for footer

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V1
+    class ApiController < ApplicationController
+      rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+      private
+
+        def record_not_found(error)
+          render json: { error: error.message }, status: :not_found
+        end
+    end
+  end
+end

--- a/app/controllers/api/v1/distributions_controller.rb
+++ b/app/controllers/api/v1/distributions_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    class DistributionsController < Api::V1::ApiController
+      def show
+        @distribution = Distribution.find(params[:id])
+        render json: @distribution
+      end
+    end
+  end
+end
+

--- a/config/initializers/cdn_footer.rb
+++ b/config/initializers/cdn_footer.rb
@@ -1,2 +1,2 @@
 #ruta de footer cdn
-CDN_URL = ENV['CDN_URL'] || 'https://cdn.datos.gob.mx/bower_components/'
+ENV['CDN_URL'] = ENV['CDN_URL'] || 'https://cdn.datos.gob.mx/bower_components/'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Adela::Application.routes.draw do
         get 'contact_point', on: :member
       end
 
+      resources :distributions, only: [:show]
+
       resources :organizations, only: [:show] do
         get 'inventory', on: :member
         get 'documents', on: :member

--- a/spec/controllers/api/v1/distributions_controller_spec.rb
+++ b/spec/controllers/api/v1/distributions_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Api::V1::DistributionsController do
+  describe 'GET /api/v1/distributions/:id' do
+    before do
+      get :show, id: distribution.id, format: :json
+    end
+
+    context 'with an existing distribution' do
+      let(:distribution) { create(:distribution) }
+
+      it 'responds with HTPP Ok' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'without an existing distribution' do
+      let(:distribution) { OpenStruct.new(id: 0) }
+
+      it 'responds with HTPP Not Found' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Changelog

* Set the default value  CDN_URL = https://cdn.datos.gob.mx/bower_components/ in order to see the footer component when this variable was not set. 

####  M: config/initializers/cdn_footer.rb

#### How to test: Follow the next step:

1)  Start up your local environment and the next component must have been the default value:
a) https://cdn.datos.gob.mx/bower_components/polymer/polymer.html
b) https://cdn.datos.gob.mx/bower_components/dgm-footer/dgm-footer.html

