### PR TITLE
Fix: separate tasks on migrations refined

### DIFF
--- a/lib/tasks/clear_data.rake
+++ b/lib/tasks/clear_data.rake
@@ -1,7 +1,7 @@
 namespace :clear_data do
     desc "Destroy datasets without distributions"
     task destroy_datasets_without_distributions: :environment do
-        Dataset.includes(:distributions).where(distributions: { id: nil }).destroy_all
+        datasets = Dataset.includes(:distributions).where(distributions: { id: nil }).delete_all
     end
 
     desc "Update issued column"


### PR DESCRIPTION
### Changelog

* TODO: Correccion tarea para actualizar titulos repetidos

### How to test

* TODO: Correr tareas clear_data:fix_invalid_title_dataset y clear_data:fix_invalid_distribution
