### PR TITLE
Fix callback method run transitions

### DIFF
--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -2,7 +2,7 @@ module Publishable
   extend ActiveSupport::Concern
 
   included do
-    after_commit :run_transitions
+    after_commit :run_transitions, on: [:create, :update]
 
     state_machine initial: :broke do
       state :broke


### PR DESCRIPTION
### Changelog

 * TODO: Modification to avoid call the callback method "run_transitions" when delete dataset because it has been delivered an error to any dataset which has not been plublished before.

 * M: app/models/concerns/publishable.rb

### How to test

* TODO:  Enter to  the Adela Systes and select the option "Plan de Apertura" and delete any  dataset which has been published before.

