### PR TITLE
Removes unneeded validations from the organization model

### DIFF
--- a/app/controllers/organizations/documents_controller.rb
+++ b/app/controllers/organizations/documents_controller.rb
@@ -3,9 +3,12 @@ class Organizations::DocumentsController < ApplicationController
   before_action :create_documents_dataset, only: :update
 
   def update
-    if current_organization.update(organization_params)
+    if organization_params? && current_organization.update(organization_params)
       flash[:notice] = I18n.t('flash.notice.organization.documents.update')
+    else
+      flash[:error] = I18n.t('flash.notice.organization.documents.error')
     end
+
     redirect_to organization_documents_path
     return
   end
@@ -18,6 +21,10 @@ class Organizations::DocumentsController < ApplicationController
         memo_files_attributes: [:file],
         ministry_memo_files_attributes: [:file]
       )
+    end
+
+    def organization_params?
+      params[:organization].present?
     end
 
     def create_documents_dataset

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,9 +1,6 @@
 class Organization < ActiveRecord::Base
   extend FriendlyId
   friendly_id :title, use: [:slugged, :finders]
-  validates :ranked, inclusion: { in: [true, false] }
-  validates :title, :landing_page, :description, :gov_type, presence: true
-  validates :title, :landing_page, uniqueness: true
 
   has_one :administrator
   has_one :catalog, -> { order('created_at desc') }

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -170,6 +170,7 @@ es:
         update: "Se ha actualizado la organización exitosamente."
         documents:
           update: "Gracias por cargar tus oficios."
+          error: "Ocurrió un error al cargar tus oficios."
     alert:
       user:
         create: "Ocurrió un error al crear el usuario."


### PR DESCRIPTION
# Description

The `Organization` model contained some validations that could not be satisfied. This caused errors updating or creating objects with nested associations.

See: [DocumentsController#update:6](https://github.com/mxabierto/adela/blob/master/app/controllers/organizations/documents_controller.rb#L6)