### PR TITLE
Fix tags dataset

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -40,7 +40,7 @@ class Dataset < ActiveRecord::Base
   end
 
   def keywords
-    "#{keyword},#{sectors}".chomp(',').lchomp(',').downcase.strip
+    "#{keyword.chomp(',')},#{sectors}".chomp(',').lchomp(',').downcase.strip
   end
 
   def openess_rating

--- a/app/views/inventories/datasets/new.html.haml
+++ b/app/views/inventories/datasets/new.html.haml
@@ -28,7 +28,7 @@
         .col-xs-4
           .form-group.required
             = f.label :publish_date, class: 'control-label'
-            = f.text_field :publish_date, class: 'datepicker form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.publish_date')}"
+            = f.text_field :publish_date, required: true, class: 'datepicker form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.dataset.publish_date')}"
     .col-md-3
       %p.margin-top
         Un <strong>Conjunto de datos</strong> es un grupo de Recursos de Datos Abiertos que tienen un tema en común.
@@ -59,7 +59,7 @@
               .col-xs-6
                 .form-group.required
                   = distribution_form.label :publish_date, class: 'control-label'
-                  = distribution_form.text_field :publish_date, class: 'datepicker publish-date form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}", 'data-placement': 'bottom'
+                  = distribution_form.text_field :publish_date, required: true, class: 'datepicker publish-date form-control', 'data-toggle': 'tooltip', title: "#{t('tooltip.distribution.publish_date')}", 'data-placement': 'bottom'
               .col-xs-6
                 .form-group
                   = distribution_form.hidden_field :media_type, class: 'form-control media_type'


### PR DESCRIPTION
### Changelog

* TODO: Method is added to eliminate the last comma of the dataset's tags field

### How to test

* TODO: Create or modify dataset's tags field with a comma to the end of text and publish dataset
