### PR TITLE
changing email by user in reret password view

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -1,5 +1,5 @@
 %p
-  Hola #{@resource.email}!
+  Hola #{@resource.name}!
 %p Alguien ha solicitado cambiar tu contraseña. Puedes hacerlo accediendo al siguiente link:
 %p= link_to 'Cambiar mi contraseña', edit_user_password_url(:reset_password_token => @token)
 %p Si no solicitaste el cambio de contraseña, por favor ignora este correo.


### PR DESCRIPTION
Changelog

Changin the email by username when the user forgot his password.

M: app/views/devise/mailer/reset_password_instructions.html.haml

Do the follow the next steps:

Downlaod this source and start up your local environment.

Modify in your local environment:

A) add the gem letter_opener_web like this:

group :development do
gem 'letter_opener_web'
end

B) In the file config/initializers/devise.rb modify the next:

Coment the next line:
#config.mailer_sender = ENV['MAILER_FROM']

Add the next two lines
ENV['MAILER_FROM'] = 'your-valid-mail@domain'
config.mailer_sender = ENV['MAILER_FROM']

C) run bundler


How to test:

D) In the login page http://localhost:port/
E) Press the button " Olvidaste tu contraseña"
F) In the next page type a valid mail and press the button "Enviar"
G) The output you must see a windows which simulate the mail:

The original Fix:

Hola "value of the email"

Now you must see:

Hola "value of the user name"
