### PR TITLE
chaging-format-allowed-to-load-from-.xlsx-by-.xls

### DIFF
--- a/app/models/designation_file.rb
+++ b/app/models/designation_file.rb
@@ -4,5 +4,5 @@ class DesignationFile < ActiveRecord::Base
 
   mount_uploader :file, DesignationFileUploader
   validates_presence_of :file
-  validates_format_of :file,  :with => %r{\.(txt|doc|docx|xlsx|xsls|pdf)}i
+  validates_format_of :file,  :with => %r{\.(txt|doc|docx|xlsx|xls|pdf)}i
 end

--- a/app/models/memo_file.rb
+++ b/app/models/memo_file.rb
@@ -4,5 +4,5 @@ class MemoFile < ActiveRecord::Base
 
   mount_uploader :file, MemoFileUploader
   validates_presence_of :file
-  validates_format_of :file,  :with => %r{\.(txt|doc|docx|xlsx|xsls|pdf)}i
+  validates_format_of :file,  :with => %r{\.(txt|doc|docx|xlsx|xls|pdf)}i
 end

--- a/app/models/ministry_memo_file.rb
+++ b/app/models/ministry_memo_file.rb
@@ -4,5 +4,5 @@ class MinistryMemoFile < ActiveRecord::Base
 
   mount_uploader :file, MinistryMemoFileUploader
   validates_presence_of :file
-  validates_format_of :file,  :with => %r{\.(txt|doc|docx|xlsx|xsls|pdf)}i
+  validates_format_of :file,  :with => %r{\.(txt|doc|docx|xlsx|xls|pdf)}i
 end

--- a/app/views/organizations/documents/index.html.haml
+++ b/app/views/organizations/documents/index.html.haml
@@ -5,11 +5,11 @@
     = form_for current_organization, url: update_organization_documents_path, method: :put do |f|
       = f.fields_for :designation_files, current_organization.designation_files.build do |designation_file_form|
         .form-group.required
-          %label.strong Selecciona el archivo del Oficio de Designación (.txt|.doc|.docx|.xlsx|.xsls|.pdf)
+          %label.strong Selecciona el archivo del Oficio de Designación (.txt|.doc|.docx|.xlsx|.xls|.pdf)
           = designation_file_form.file_field :file
       = f.fields_for :memo_files, current_organization.memo_files.build  do |memo_file_form|
         .form-group.required
-          %label.strong Selecciona el archivo de la Minuta de Autorizaci&oacute;n del Grupo de Trabajo (.txt|.doc|.docx|.xlsx|.xsls|.pdf)
+          %label.strong Selecciona el archivo de la Minuta de Autorizaci&oacute;n del Grupo de Trabajo (.txt|.doc|.docx|.xlsx|.xls|.pdf)
           = memo_file_form.file_field :file
       .form-group
         %button.btn.btn-primary{ type: 'submit' } Subir documentos


### PR DESCRIPTION
# Changelog

##  Changin format .xsls by .xls

* M: app/models/designation_file.rb
* M: app/models/memo_file.rb
* M: app/models/ministry_memo_file.rb
* M: app/views/organizations/documents/index.html.haml

### How to test

* Follow the next steps:

1) Download this branch.
2) Startup your local environment.
3) In the optión of menu select option called "Documentos" and in the description you must see the next list of valid formats such as: (.txt|.doc|.docx|.xlsx|.xls|.pdf).



