### PR TITLE
changing message upload documents

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -172,7 +172,7 @@ es:
         update: "Se ha actualizado la organización exitosamente."
         documents:
           update: "Gracias por cargar tus oficios."
-          error: "Ocurrió un error al cargar tus oficios."
+          error: "El formato del archivo(s) no es válido, seleccione un formato permitido (.txt|.doc|.docx |.xlsx|.xls|.pdf)"
     alert:
       user:
         create: "Ocurrió un error al crear el usuario."


### PR DESCRIPTION
### Changelog

* Changing error message at the momento of upload documents.
* M: config/locales/es.yml

###  Following the next steps:

1) Download this branch.
2) Startup your local environment.

### How to test

Select the option of the menu "Documentos" and select any kind of documento diferent from the next format: (.txt|.doc|.docx |.xlsx|.xls|.pdf) and press the button "Subir documentos " and you must see the message error: El formato del archivo(s) no es válido, seleccione un formato permitido (.txt|.doc|.docx |.xlsx|.xls|.pdf) , Instead of watching: Ocurrió un error al cargar tus oficios.



