### PR TITLE
adding responsible publish

### DIFF
--- a/app/serializers/dataset_serializer.rb
+++ b/app/serializers/dataset_serializer.rb
@@ -31,6 +31,11 @@ class DatasetSerializer < ActiveModel::Serializer
       position: object.contact_position,
       mbox: object.mbox
     }
+    data[:responsible] = {
+      position: object.contact_position,
+      mbox: object.mbox,
+      contact_name: object.contact_name
+    }
     data[:public] = object.public_access
     data[:publishDate] = object.publish_date
     data


### PR DESCRIPTION
### Changelog

* TODO: Adding responsible publish 

* M: app/serializers/dataset_serializer.rb

### How to test

* Follow the next steps:
1)  Download this branch.
2)  Startup your local environment.
3)  Fill the next fields in the view "Documentar un Conjunto de Datos":

Cargo del responsable,
Correo del responsable,
Nombre de responsable del Conjunto

4) Publishe the dataset.
5) In the http://URL:port/organizacion/catalogo.json , you must see the next values:

"responsible": {
    "position": "Value typed in this field in Adela documented dataset",
    "mbox": "Value typed in this field in Adela documented dataset",
    "contact_name": "Value typed in this field in Adela documented dataset"
  },