### PR TITLE
fix keyword validations

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -96,6 +96,8 @@ es:
               blank: 'Un conjunto de datos debe de contener al menos un Recurso de Datos.'
             temporal:
               invalid: 'La fecha del inicio del período de tiempo cubierto debe ser menor al fin del periodo.'
+            keyword:
+              invalid: 'la longitud supera los 25 caracteres: '
         distribution:
           attributes:
             title:


### PR DESCRIPTION
### Changelog

### M: app/models/dataset.rb

* TODO: Validations and transformations to the datasetś keyword. 

### How to test

You must get in to the Adela system and try to edit any dataset and the system must do the next validation and the transformations describes below

### Validation:

a) If you write more than 25 characteres the system do not let you save dataSet and the system show the message all those keywords that exceed the 25 characters.

### Transformation to he keywords:

1)  all keyword must be convert to downcase.
2) all  symbols like "" or '' must be deleted.
3) all space between keyword must be replace by -
4) all , whitout any word must be deleted.






