### PR TITLE
validación de caracteres especiales

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -97,7 +97,8 @@ es:
             temporal:
               invalid: 'La fecha del inicio del período de tiempo cubierto debe ser menor al fin del periodo.'
             keyword:
-              invalid: 'la longitud supera los 25 caracteres: '
+              invalid: 'supera los 25 caracteres permitidos: '
+              format:  'puede estar formada por caracteres alfanumericos, guion medio (-) y bajo (_) ;corrija las siguientes: '
         distribution:
           attributes:
             title:

--- a/config/locales/tooltips/forms/dataset.yml
+++ b/config/locales/tooltips/forms/dataset.yml
@@ -17,6 +17,6 @@ es:
         term: Fin del período temporal que abarca el conjunto de datos. Algunos ejemplos son, "2014”, "2014-04", etc.
       data_dictionary: Dirección electrónica del diccionario de datos del Conjunto. Por ejemplo, "http://bit.ly/1t5IFsb".
       sector: Sector al que pertenece el Conjunto de Datos según el tema que trata.
-      keyword: Lista de términos clave separados por coma, que facilitarán al usuario la búsqueda del conjunto de datos. Es importante considerar el uso de términos no técnicos; por ejemplo, "salud", "medicinas", "compras", "agricultura", etc.
+      keyword: Listado de términos clave separados por coma, los cuales tienen como finalidad facilitar al usuario la búsqueda de información IMPORTANTE; se debe considerar el uso de términos no técnicos y únicamente con caracteres alfanuméricos. Por ejemplo, contratos, medicinas, compras, agricultura.
       comments: Comentarios adicionales sobre el conjunto. Por ejemplo, "La continuidad a los datos estará a cargo de [Nombre Dependencia] a partir del [Fecha]".
       quality: Dirección electrónica donde se puede consultar el proceso que se sigue para asegurar la calidad de los datos. Por ejemplo, "http://bit.ly/1a2b3c4".


### PR DESCRIPTION
### Changelog

* TODO: Se validan caracteres especiales al Documentar un Conjunto de Datos
en el campo de "validate-special-caracteres-dataset"
* M: app/models/dataset.rb
* M: config/locales/es.yml
* M: config/locales/tooltips/forms/dataset.yml
### How to test
* Follow the next steps:
1)  Download this PR.
2)  Start up your local environment.
3)  Select the menu "Cátalogo de Datos" and documen the dataset.
4) In the field "Palabras clave (separadas por coma)" you can introduce the and you can use:
a) Alfanumerics (A-Z and a-z, 0-9 and Accents , - or _).

### Validations: 

In case that the kryword are not allowed; the system shows: 
"Palabra clave puede estar formada por caracteres alfanumericos, guion medio (-) y bajo (_) ;corrija las siguientes: "List all the words that are not allowed" 

