### PR TITLE
fixing tooltips keywords and lenght 25 maximum

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -73,13 +73,15 @@ class Dataset < ActiveRecord::Base
 
     def validate_format
      arrayIn = self.keyword.split(',')
+     arrayIn.select { |item| item.strip! }
      arrayIn.delete_if {|item| !(item.match(/\A[a-zA-ZñÑáéíóúÁÉÍÓÚ0-9 _-]*\z/).nil?)}  
      errors.add(:Palabra_clave, I18n.t("activerecord.errors.models.dataset.attributes.keyword.format") +
                                        "#{arrayIn.join(',')}") if arrayIn.length > 0
     end   
 
     def validate_keyword_lengh
-      array = self.keyword.split(',')    
+      array = self.keyword.split(',')
+      array.select { |item| item.strip! }    
       errors.add(:Palabra_clave, I18n.t("activerecord.errors.models.dataset.attributes.keyword.invalid") +
                                   "#{array.select{ |item| item.length > 25}.join(',')}") if array.select { |item| item.length > 25 }.size > 0
     end

--- a/config/locales/tooltips/forms/dataset.yml
+++ b/config/locales/tooltips/forms/dataset.yml
@@ -17,6 +17,6 @@ es:
         term: Fin del período temporal que abarca el conjunto de datos. Algunos ejemplos son, "2014”, "2014-04", etc.
       data_dictionary: Dirección electrónica del diccionario de datos del Conjunto. Por ejemplo, "http://bit.ly/1t5IFsb".
       sector: Sector al que pertenece el Conjunto de Datos según el tema que trata.
-      keyword: Listado de términos clave separados por coma, los cuales tienen como finalidad facilitar al usuario la búsqueda de información IMPORTANTE; se debe considerar el uso de términos no técnicos y únicamente con caracteres alfanuméricos. Por ejemplo, contratos, medicinas, compras, agricultura.
+      keyword: Listado de términos clave separados por coma, los cuales tienen como finalidad facilitar al usuario la búsqueda de información. IMPORTANTE se debe considerar el uso de términos no-técnicos y únicamente con caracteres alfanuméricos, con no más de 25 caracteres. EJEMPLOS contratos, compra-de-medicinas, agricultura
       comments: Comentarios adicionales sobre el conjunto. Por ejemplo, "La continuidad a los datos estará a cargo de [Nombre Dependencia] a partir del [Fecha]".
       quality: Dirección electrónica donde se puede consultar el proceso que se sigue para asegurar la calidad de los datos. Por ejemplo, "http://bit.ly/1a2b3c4".


### PR DESCRIPTION
### Changelog

* TODO: Fixing lenght maxim words of keyword deleting spaces and changin message of tooltip.
* M: app/models/dataset.rb
* M: config/locales/tooltips/forms/dataset.yml
### How to test

###Follow the next steps:

1) Download this Pr.
2) Start up your local changes.
3) In the menu "Catálogo de Datos" at the momento of documented any dataset.
4) Introduce keywords that exceed 25 characters usging spaces at the begin and the end of it.
